### PR TITLE
Location fields reset after adding a new agency

### DIFF
--- a/components/Agencies.jsx
+++ b/components/Agencies.jsx
@@ -84,6 +84,7 @@ const Agencies = ({handleAgencyUpdateSubmit}) => {
 	// Modal for new agencies. Modal is displayed when users click the button to add a new agency.
 	const handleAddNewAgencyModal = (e) => {
 		e.preventDefault()
+		setData({ country: 'US', state: null, city: null })
 		setNewAgencyModal(true)
 	}
 	// Handler: new agency NAME


### PR DESCRIPTION
Locations fields reset when trying to add a new agency just after adding a new agency.