### PR TITLE
Bug/npm run dev issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,17 @@ To boot up the development server and Firebase Emulator run:
 npm run dev
 ```
 
-This command will boot up the [Firebase Emulator UI](https://firebase.google.com/docs/emulator-suite) and the NextJS server. Look over your terminal output and click the Emulator links (Emulator UI) and localhost link.
+This command starts the [Firebase Emulator UI](https://firebase.google.com/docs/emulator-suite) and the Next.js dev server. Use the Emulator UI link from the terminal when you need Auth/Firestore/etc. tools.
+
+**Open the app in your browser at [http://localhost:3000](http://localhost:3000).** `npm run dev` starts Auth, Firestore, Functions, Storage, and Extensions emulators **without** the Hosting emulator, so there is only one Next.js process (this one). That avoids duplicate dev servers and keeps your browser origin on `localhost:3000`, which matches typical Google Cloud API key HTTP referrer rules for the Firebase Web SDK.
+
+`npm run dev:turbo` is the same as `npm run dev` (Next.js already uses Turbopack for local dev here).
+
+`npm run dev:live` starts **only** Next.js (`next dev`), sets `NEXT_PUBLIC_USE_EMULATORS=false`, and **unsets** common `*_EMULATOR_HOST` variables for that process. If your shell profile exports `FIRESTORE_EMULATOR_HOST` (or similar) for other work, leaving it set can still point the SDK at a local port with no emulator running, which looks like “offline” Firestore. This script clears that mismatch. It also opts the browser into Firestore long-polling auto-detect when not using emulators, which avoids some flaky WebChannel errors under `next dev`.
+
+With `dev:live` you are talking to the **real** Firebase project, so **Firestore security rules** apply like production (sign in with a user that exists in **production** Auth, not the emulator-only test emails). A common blocker is **App Check**: Google’s “prove this browser is really your app” layer often rejects `localhost` until you register an **App Check debug token**. If you do not set `NEXT_PUBLIC_FIREBASE_APPCHECK_DEBUG_TOKEN` in `.env.local`, this app turns on Firebase’s debug flow automatically during **development when not using emulators**—check the browser console for a token string, then add it once in [Firebase Console → App Check → your web app → Manage debug tokens](https://firebase.google.com/docs/app-check/web/debug-provider). For day-to-day feature work, prefer **`npm run dev`** with emulators and the seeded test accounts below.
+
+If you ever need to exercise the **Hosting** emulator itself, run `firebase emulators:start --import=./emulator-data` in a separate terminal (without also running `npm run dev` in this repo’s usual way), and expect a second Next instance and a non-`:3000` URL—see [Firebase Hosting local dev](https://firebase.google.com/docs/emulator-suite/connect_hosting).
 
 #### Emulator Users
 
@@ -77,7 +87,7 @@ The emulator has 3 user accounts already set up. You can log in with any of them
 - email: admin@user.com
 - pass: devPassword
 
-You can also sign up with totally different info (email, name, city, state ect.). When you sign up a authorization link will print out in your terminal. You will need to click that link to verify. After you click the link you can close the window that open's (its only for verification) and return to your localhost window to log in.
+You can also sign up with totally different info (email, name, city, state ect.). When you sign up a authorization link will print out in your terminal. You will need to click that link to verify. After you click the link you can close the window that open's (its only for verification) and return to [http://localhost:3000](http://localhost:3000) to log in.
 
 ## Emulator Tips:
 

--- a/components/profile/SwitchRead.jsx
+++ b/components/profile/SwitchRead.jsx
@@ -19,7 +19,7 @@
  */
 import { useEffect, useState } from "react"
 import { useRouter } from "next/router"
-import { getDoc, doc, updateDoc, collection, app } from "firebase/firestore"
+import { getDoc, doc, updateDoc, collection } from "firebase/firestore"
 import { db } from "../../config/firebase"
 import { Switch } from "@headlessui/react"
 import { MdMarkAsUnread, MdMarkEmailRead } from "react-icons/md"

--- a/config/firebase.js
+++ b/config/firebase.js
@@ -21,7 +21,11 @@
 import { initializeApp } from 'firebase/app'
 
 import { getAuth, connectAuthEmulator } from 'firebase/auth'
-import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore'
+import {
+	getFirestore,
+	initializeFirestore,
+	connectFirestoreEmulator,
+} from 'firebase/firestore'
 import { getStorage, connectStorageEmulator } from 'firebase/storage'
 import { getAnalytics } from 'firebase/analytics'
 import { getPerformance } from 'firebase/performance'
@@ -51,6 +55,47 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = initializeApp(firebaseConfig)
 
+/** True when this build should wire the client SDK to local emulators. */
+const useEmulators =
+	process.env.NODE_ENV === 'development' &&
+	process.env.NEXT_PUBLIC_USE_EMULATORS === 'true'
+
+/**
+ * Creates the Firestore client for this JS realm.
+ * Uses long-polling auto-detect in the browser when not on emulators so `next dev` is less likely to hit flaky WebChannel streams to the real backend.
+ */
+function createFirestore() {
+	if (typeof window === 'undefined') {
+		return getFirestore(app)
+	}
+	if (useEmulators) {
+		return getFirestore(app)
+	}
+	try {
+		return initializeFirestore(app, {
+			experimentalAutoDetectLongPolling: true,
+		})
+	} catch {
+		return getFirestore(app)
+	}
+}
+
+// Auth + Firestore must exist (and emulators must be attached) before Analytics / App Check
+// so the Firestore client is not pre-configured with a production host.
+export const auth = getAuth(app)
+export const db = createFirestore()
+
+if (useEmulators && typeof globalThis !== 'undefined') {
+	if (!globalThis.__MISINFO_AUTH_FIRESTORE_EMULATOR__) {
+		globalThis.__MISINFO_AUTH_FIRESTORE_EMULATOR__ = true
+		console.log('Running Emulator')
+		connectAuthEmulator(auth, 'http://127.0.0.1:9099', {
+			disableWarnings: true,
+		})
+		connectFirestoreEmulator(db, '127.0.0.1', 8080)
+	}
+}
+
 // Initialize Analytics and Performance Monitoring if running in the browser
 let analytics = null // Initialize to null
 let perf = null
@@ -70,18 +115,29 @@ if (typeof window !== 'undefined') {
 	} catch (e) {
 		perf = null
 	}
+	// App Check on localhost + real Firebase: without a valid debug token, Firestore often returns
+	// “Missing or insufficient permissions” even when signed in. If NEXT_PUBLIC_FIREBASE_APPCHECK_DEBUG_TOKEN
+	// is unset, use `true` so Firebase logs a token once per load (development + not on emulators).
+	// Register it under Firebase Console → App Check → your web app → Manage debug tokens.
+	const liveLocalDev =
+		process.env.NODE_ENV === 'development' &&
+		process.env.NEXT_PUBLIC_USE_EMULATORS !== 'true'
+	if (process.env.NEXT_PUBLIC_FIREBASE_APPCHECK_DEBUG_TOKEN) {
+		self.FIREBASE_APPCHECK_DEBUG_TOKEN =
+			process.env.NEXT_PUBLIC_FIREBASE_APPCHECK_DEBUG_TOKEN
+	} else if (liveLocalDev) {
+		self.FIREBASE_APPCHECK_DEBUG_TOKEN = true
+	}
 	// Initialize App Check with ReCaptcha Enterprise
 	// Docs: https://firebase.google.com/docs/app-check/web/debug-provider?authuser=0
 	try {
-		self.FIREBASE_APPCHECK_DEBUG_TOKEN =
-			process.env.NEXT_PUBLIC_FIREBASE_APPCHECK_DEBUG_TOKEN
 		initializeAppCheck(app, {
 			provider: new ReCaptchaEnterpriseProvider(
 				process.env.NEXT_PUBLIC_FIREBASE_RECAPTCHA_ENTERPRISE_SITE_KEY,
 			),
-			isTokenAutoRefreshEnabled: true, // Set to true to allow auto-refresh.
+			isTokenAutoRefreshEnabled: true, // Set to true to allow token auto-refresh.
 		})
-		appCheck = true  // optional: signal success
+		appCheck = true // optional: signal success
 	} catch (e) {
 		appCheck = null
 	}
@@ -89,23 +145,26 @@ if (typeof window !== 'undefined') {
 
 export { app, analytics, perf, appCheck }
 
-export const db = getFirestore(app)
 // Storage: init only in browser when storageBucket is set; otherwise getStorage() throws "Service storage is not available"
 let storage = null
 if (typeof window !== 'undefined') {
 	if (firebaseConfig.storageBucket) {
 		try {
-			const bucketUrl = firebaseConfig.storageBucket.startsWith('gs://') ? firebaseConfig.storageBucket : `gs://${firebaseConfig.storageBucket}`
+			const bucketUrl = firebaseConfig.storageBucket.startsWith('gs://')
+				? firebaseConfig.storageBucket
+				: `gs://${firebaseConfig.storageBucket}`
 			storage = getStorage(app, bucketUrl)
 		} catch {
 			storage = null
 		}
 	} else {
-		console.warn('Firebase Storage skipped: NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET is not set. Set it in .env to enable uploads.')
+		console.warn(
+			'Firebase Storage skipped: NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET is not set. Set it in .env to enable uploads.',
+		)
 	}
 }
 export { storage }
-export const auth = getAuth(app)
+
 // Functions: init only in browser; try/catch so any SDK throw (build, SSR, edge) yields null instead of crash
 let functions = null
 if (typeof window !== 'undefined') {
@@ -117,12 +176,15 @@ if (typeof window !== 'undefined') {
 }
 export { functions }
 
-// Connect to Firebase emulators in development mode
-// Only connect if USE_EMULATORS environment variable is set to 'true'
-if (process.env.NODE_ENV === 'development' && process.env.NEXT_PUBLIC_USE_EMULATORS === 'true') {
-	console.log('Running Emulator')
-	connectAuthEmulator(auth, 'http://127.0.0.1:9099')
-	connectFirestoreEmulator(db, 'localhost', 8080)
-	if (storage) connectStorageEmulator(storage, '127.0.0.1', 9199)
-	if (functions) connectFunctionsEmulator(functions, '127.0.0.1', 5001)
+// Storage / Functions emulators (after instances exist). Separate global flags so a null storage
+// on first SSR pass does not skip browser-only emulator wiring on the client.
+if (useEmulators && typeof globalThis !== 'undefined') {
+	if (storage && !globalThis.__MISINFO_STORAGE_EMULATOR__) {
+		globalThis.__MISINFO_STORAGE_EMULATOR__ = true
+		connectStorageEmulator(storage, '127.0.0.1', 9199)
+	}
+	if (functions && !globalThis.__MISINFO_FUNCTIONS_EMULATOR__) {
+		globalThis.__MISINFO_FUNCTIONS_EMULATOR__ = true
+		connectFunctionsEmulator(functions, '127.0.0.1', 5001)
+	}
 }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -13,7 +13,7 @@
         "child-process-promise": "^2.2.1",
         "dotenv": "^16.4.5",
         "firebase-admin": "^12.4.0",
-        "firebase-functions": "^4.8.1",
+        "firebase-functions": "^7.2.5",
         "imagemagick": "^0.1.3",
         "mkdirp": "^3.0.1"
       },
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@google-cloud/firestore": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.10.0.tgz",
-      "integrity": "sha512-VFNhdHvfnmqcHHs6YhmSNHHxQqaaD64GwiL0c+e1qz85S8SWZPC2XFRf8p9yHRTF40Kow424s1KBU9f0fdQa+Q==",
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.6.tgz",
+      "integrity": "sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -225,18 +225,18 @@
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.13.0.tgz",
-      "integrity": "sha512-Y0rYdwM5ZPW3jw/T26sMxxfPrVQTKm9vGrZG8PRyGuUmUJ8a2xNuQ9W/NNA1prxqv2i54DSydV8SJqxF2oCVgA==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
+      "integrity": "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/paginator": "^5.0.0",
         "@google-cloud/projectify": "^4.0.0",
-        "@google-cloud/promisify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
         "abort-controller": "^3.0.0",
         "async-retry": "^1.3.3",
         "duplexify": "^4.1.3",
-        "fast-xml-parser": "^4.4.1",
+        "fast-xml-parser": "^5.3.4",
         "gaxios": "^6.0.2",
         "google-auth-library": "^9.6.3",
         "html-entities": "^2.5.2",
@@ -337,6 +337,18 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
+      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -541,20 +553,21 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.3.tgz",
-      "integrity": "sha512-I8cGRJj3pyOLs/HndoP+25vOqhqWkAZsWMEmq1qXy/b/M3ppufecUwaK2/TVDVxcV61/iSdhykUjQQ2DLSrTdg==",
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
-        "@types/serve-static": "*"
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.0.tgz",
-      "integrity": "sha512-AbXMTZGt40T+KON9/Fdxx0B2WK5hsgxcfXJLr5bFpZ7b4JCex2WyQPTEKdXqfHiY5nKKBScZ7yCoO6Pvgxfvnw==",
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -718,9 +731,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -859,23 +872,23 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
@@ -891,16 +904,45 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1129,9 +1171,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1610,21 +1652,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1660,10 +1687,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
-      "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -1672,7 +1699,25 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
+      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^1.1.0",
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -1764,14 +1809,14 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.6.0.tgz",
-      "integrity": "sha512-gc0pDiUmxscxBhcjMcttmjvExJmnQdVRb+IIth95CvMm7F9rLdabrQZThW2mK02HR696P+rzd6NqkdUA3URu4w==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.7.0.tgz",
+      "integrity": "sha512-raFIrOyTqREbyXsNkSHyciQLfv8AUZazehPaQS1lZBSCDYW74FYXU0nQZa3qHI4K+hawohlDbywZ4+qce9YNxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
-        "@firebase/database-compat": "^1.0.2",
-        "@firebase/database-types": "^1.0.0",
+        "@firebase/database-compat": "1.0.8",
+        "@firebase/database-types": "1.0.5",
         "@types/node": "^22.0.1",
         "farmhash-modern": "^1.1.0",
         "jsonwebtoken": "^9.0.0",
@@ -1788,26 +1833,39 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-4.8.1.tgz",
-      "integrity": "sha512-SHA7ZUlG+MOOsKyp+D4vhSyF4FsJMD+qyVUkTcPry6wbbxDitv9k4xgUPXffhbiokxFi1AbeckA8SGD41AZiCg==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.2.5.tgz",
+      "integrity": "sha512-K+pP0AknluAguLRbD96hibyXbnOgwnvd4hkExWdGrxnNCLoj8LBFj08uvJYxyvhsCgYzQumrUaHBW4lsXKSiRg==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",
-        "@types/express": "4.17.3",
+        "@types/express": "^4.17.21",
         "cors": "^2.8.5",
-        "express": "^4.17.1",
-        "node-fetch": "^2.6.7",
+        "express": "^4.21.0",
         "protobufjs": "^7.2.2"
       },
       "bin": {
         "firebase-functions": "lib/bin/firebase-functions.js"
       },
       "engines": {
-        "node": ">=14.10.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "firebase-admin": "^10.0.0 || ^11.0.0 || ^12.0.0"
+        "@apollo/server": "^5.2.0",
+        "@as-integrations/express4": "^1.1.2",
+        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0",
+        "graphql": "^16.12.0"
+      },
+      "peerDependenciesMeta": {
+        "@apollo/server": {
+          "optional": true
+        },
+        "@as-integrations/express4": {
+          "optional": true
+        },
+        "graphql": {
+          "optional": true
+        }
       }
     },
     "node_modules/flat-cache": {
@@ -1853,14 +1911,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.2.tgz",
-      "integrity": "sha512-GgwY0PS7DbXqajuGf4OYlsrIu3zgxD6Vvql43IBhm6MahqA5SK/7mwhtNj2AdH2z35YR34ujJ7BN+3fFC3jP5Q==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
+      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
       "engines": {
@@ -2064,9 +2124,9 @@
       }
     },
     "node_modules/google-gax": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.4.1.tgz",
-      "integrity": "sha512-Phyp9fMfA00J3sZbJxbbB4jC55b7DBjE3F6poyL3wKMEBVKA79q6BGuHcTiM28yOzVql0NDbRL8MLLh8Iwk9Dg==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
+      "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.10.9",
@@ -2408,9 +2468,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2473,33 +2533,33 @@
       }
     },
     "node_modules/jsonwebtoken/node_modules/jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
       "license": "MIT",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jsonwebtoken/node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jwa": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
@@ -2521,37 +2581,13 @@
         "node": ">=14"
       }
     },
-    "node_modules/jwks-rsa/node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/jwks-rsa/node_modules/@types/express-serve-static-core": {
-      "version": "4.19.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
-      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
     "node_modules/jws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^2.0.0",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -2978,6 +3014,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3095,12 +3146,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -3140,16 +3191,45 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -3549,9 +3629,15 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/stubs": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -21,7 +21,7 @@
     "child-process-promise": "^2.2.1",
     "dotenv": "^16.4.5",
     "firebase-admin": "^12.4.0",
-    "firebase-functions": "^4.8.1",
+    "firebase-functions": "^7.2.5",
     "imagemagick": "^0.1.3",
     "mkdirp": "^3.0.1"
   },

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,8 @@
 
 const { i18n } = require('./next-i18next.config.js');
 
+const useFirebaseEmulators = process.env.NEXT_PUBLIC_USE_EMULATORS === 'true';
+
 const nextConfig = {
   i18n,
   reactStrictMode: true,
@@ -44,10 +46,11 @@ const nextConfig = {
       {
         protocol: 'http',
         hostname: '127.0.0.1',
-      }
+      },
     ],
+    ...(useFirebaseEmulators ? { dangerouslyAllowLocalIP: true } : {}),
   },
-  
+
   webpack: (config, { isServer }) => {
     if (!isServer) {
       config.resolve = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3094,17 +3094,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@jridgewell/source-map": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-			"integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.25"
-			}
-		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -5364,28 +5353,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/eslint": {
-			"version": "9.6.1",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-			"integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/estree": "*",
-				"@types/json-schema": "*"
-			}
-		},
-		"node_modules/@types/eslint-scope": {
-			"version": "3.7.7",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/eslint": "*",
-				"@types/estree": "*"
-			}
-		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5524,16 +5491,6 @@
 			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
 			"integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
 			"license": "MIT"
-		},
-		"node_modules/@types/react": {
-			"version": "19.2.14",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"csstype": "^3.2.2"
-			}
 		},
 		"node_modules/@types/react-transition-group": {
 			"version": "4.4.12",
@@ -6177,181 +6134,6 @@
 				"win32"
 			]
 		},
-		"node_modules/@webassemblyjs/ast": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
-			"integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@webassemblyjs/helper-numbers": "1.13.2",
-				"@webassemblyjs/helper-wasm-bytecode": "1.13.2"
-			}
-		},
-		"node_modules/@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
-			"integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@webassemblyjs/helper-api-error": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
-			"integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@webassemblyjs/helper-buffer": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
-			"integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@webassemblyjs/helper-numbers": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
-			"integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@webassemblyjs/floating-point-hex-parser": "1.13.2",
-				"@webassemblyjs/helper-api-error": "1.13.2",
-				"@xtuc/long": "4.2.2"
-			}
-		},
-		"node_modules/@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
-			"integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@webassemblyjs/helper-wasm-section": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
-			"integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@webassemblyjs/ast": "1.14.1",
-				"@webassemblyjs/helper-buffer": "1.14.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-				"@webassemblyjs/wasm-gen": "1.14.1"
-			}
-		},
-		"node_modules/@webassemblyjs/ieee754": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
-			"integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@xtuc/ieee754": "^1.2.0"
-			}
-		},
-		"node_modules/@webassemblyjs/leb128": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
-			"integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@xtuc/long": "4.2.2"
-			}
-		},
-		"node_modules/@webassemblyjs/utf8": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
-			"integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@webassemblyjs/wasm-edit": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
-			"integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@webassemblyjs/ast": "1.14.1",
-				"@webassemblyjs/helper-buffer": "1.14.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-				"@webassemblyjs/helper-wasm-section": "1.14.1",
-				"@webassemblyjs/wasm-gen": "1.14.1",
-				"@webassemblyjs/wasm-opt": "1.14.1",
-				"@webassemblyjs/wasm-parser": "1.14.1",
-				"@webassemblyjs/wast-printer": "1.14.1"
-			}
-		},
-		"node_modules/@webassemblyjs/wasm-gen": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
-			"integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@webassemblyjs/ast": "1.14.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-				"@webassemblyjs/ieee754": "1.13.2",
-				"@webassemblyjs/leb128": "1.13.2",
-				"@webassemblyjs/utf8": "1.13.2"
-			}
-		},
-		"node_modules/@webassemblyjs/wasm-opt": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
-			"integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@webassemblyjs/ast": "1.14.1",
-				"@webassemblyjs/helper-buffer": "1.14.1",
-				"@webassemblyjs/wasm-gen": "1.14.1",
-				"@webassemblyjs/wasm-parser": "1.14.1"
-			}
-		},
-		"node_modules/@webassemblyjs/wasm-parser": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
-			"integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@webassemblyjs/ast": "1.14.1",
-				"@webassemblyjs/helper-api-error": "1.13.2",
-				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-				"@webassemblyjs/ieee754": "1.13.2",
-				"@webassemblyjs/leb128": "1.13.2",
-				"@webassemblyjs/utf8": "1.13.2"
-			}
-		},
-		"node_modules/@webassemblyjs/wast-printer": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
-			"integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@webassemblyjs/ast": "1.14.1",
-				"@xtuc/long": "4.2.2"
-			}
-		},
-		"node_modules/@xtuc/ieee754": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-			"license": "BSD-3-Clause",
-			"peer": true
-		},
-		"node_modules/@xtuc/long": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-			"license": "Apache-2.0",
-			"peer": true
-		},
 		"node_modules/abbrev": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
@@ -6406,19 +6188,6 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^8"
-			}
-		},
-		"node_modules/acorn-import-phases": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-			"integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=10.13.0"
-			},
-			"peerDependencies": {
-				"acorn": "^8.14.0"
 			}
 		},
 		"node_modules/acorn-jsx": {
@@ -7579,13 +7348,6 @@
 			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/buffer-from": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -7891,16 +7653,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/chrome-trace-event": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
-			"integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=6.0"
 			}
 		},
 		"node_modules/ci-info": {
@@ -9109,20 +8861,6 @@
 				"once": "^1.4.0"
 			}
 		},
-		"node_modules/enhanced-resolve": {
-			"version": "5.19.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-			"integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"graceful-fs": "^4.2.4",
-				"tapable": "^2.3.0"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
 		"node_modules/env-paths": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -9268,13 +9006,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/es-module-lexer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
@@ -9846,6 +9577,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"estraverse": "^5.2.0"
@@ -11405,13 +11137,6 @@
 				"toxic": "^1.0.0"
 			}
 		},
-		"node_modules/glob-to-regexp": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-			"license": "BSD-2-Clause",
-			"peer": true
-		},
 		"node_modules/glob/node_modules/brace-expansion": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
@@ -12910,37 +12635,6 @@
 				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
-		"node_modules/jest-worker": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-			"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/node": "*",
-				"merge-stream": "^2.0.0",
-				"supports-color": "^8.0.0"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/jest-worker/node_modules/supports-color": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
 		"node_modules/jiti": {
 			"version": "1.21.7",
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -13330,20 +13024,6 @@
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"license": "MIT"
-		},
-		"node_modules/loader-runner": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
-			"integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=6.11.5"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			}
 		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
@@ -13770,13 +13450,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/merge-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -14260,13 +13933,6 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
-		},
-		"node_modules/neo-async": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/netmask": {
 			"version": "2.0.2",
@@ -16661,81 +16327,6 @@
 				"loose-envify": "^1.1.0"
 			}
 		},
-		"node_modules/schema-utils": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
-			"integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/json-schema": "^7.0.9",
-				"ajv": "^8.9.0",
-				"ajv-formats": "^2.1.1",
-				"ajv-keywords": "^5.1.0"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			}
-		},
-		"node_modules/schema-utils/node_modules/ajv": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/schema-utils/node_modules/ajv-formats": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ajv": "^8.0.0"
-			},
-			"peerDependencies": {
-				"ajv": "^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"ajv": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/schema-utils/node_modules/ajv-keywords": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3"
-			},
-			"peerDependencies": {
-				"ajv": "^8.8.2"
-			}
-		},
-		"node_modules/schema-utils/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/semver": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -17146,6 +16737,7 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"license": "BSD-3-Clause",
+			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -17157,17 +16749,6 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/source-map-support": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
 			}
 		},
 		"node_modules/split2": {
@@ -17813,20 +17394,6 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/tapable": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-			"integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			}
-		},
 		"node_modules/tar-stream": {
 			"version": "3.1.7",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
@@ -17914,66 +17481,6 @@
 			"engines": {
 				"node": ">= 6"
 			}
-		},
-		"node_modules/terser": {
-			"version": "5.46.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
-			"integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/source-map": "^0.3.3",
-				"acorn": "^8.15.0",
-				"commander": "^2.20.0",
-				"source-map-support": "~0.5.20"
-			},
-			"bin": {
-				"terser": "bin/terser"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/terser-webpack-plugin": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
-			"integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.25",
-				"jest-worker": "^27.4.5",
-				"schema-utils": "^4.3.0",
-				"terser": "^5.31.1"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			},
-			"peerDependencies": {
-				"webpack": "^5.1.0"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"esbuild": {
-					"optional": true
-				},
-				"uglify-js": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/terser/node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/text-decoder": {
 			"version": "1.2.7",
@@ -18408,20 +17915,6 @@
 				"is-typedarray": "^1.0.0"
 			}
 		},
-		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=14.17"
-			}
-		},
 		"node_modules/unbox-primitive": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -18756,20 +18249,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/watchpack": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-			"integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"glob-to-regexp": "^0.4.1",
-				"graceful-fs": "^4.1.2"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
 		"node_modules/wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -18800,55 +18279,6 @@
 			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
 			"license": "BSD-2-Clause"
 		},
-		"node_modules/webpack": {
-			"version": "5.105.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
-			"integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/eslint-scope": "^3.7.7",
-				"@types/estree": "^1.0.8",
-				"@types/json-schema": "^7.0.15",
-				"@webassemblyjs/ast": "^1.14.1",
-				"@webassemblyjs/wasm-edit": "^1.14.1",
-				"@webassemblyjs/wasm-parser": "^1.14.1",
-				"acorn": "^8.15.0",
-				"acorn-import-phases": "^1.0.3",
-				"browserslist": "^4.28.1",
-				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.19.0",
-				"es-module-lexer": "^2.0.0",
-				"eslint-scope": "5.1.1",
-				"events": "^3.2.0",
-				"glob-to-regexp": "^0.4.1",
-				"graceful-fs": "^4.2.11",
-				"json-parse-even-better-errors": "^2.3.1",
-				"loader-runner": "^4.3.1",
-				"mime-types": "^2.1.27",
-				"neo-async": "^2.6.2",
-				"schema-utils": "^4.3.3",
-				"tapable": "^2.3.0",
-				"terser-webpack-plugin": "^5.3.16",
-				"watchpack": "^2.5.1",
-				"webpack-sources": "^3.3.3"
-			},
-			"bin": {
-				"webpack": "bin/webpack.js"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			},
-			"peerDependenciesMeta": {
-				"webpack-cli": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/webpack-sources": {
 			"version": "3.3.4",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
@@ -18863,30 +18293,6 @@
 			"resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
 			"integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
 			"license": "MIT"
-		},
-		"node_modules/webpack/node_modules/eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"dependencies": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/webpack/node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"engines": {
-				"node": ">=4.0"
-			}
 		},
 		"node_modules/websocket-driver": {
 			"version": "0.7.4",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"private": true,
 	"scripts": {
 		"dev": "./start-dev.sh",
-		"dev:live": "next dev",
+		"dev:turbo": "npm run dev",
+		"dev:live": "sh -c 'unset FIRESTORE_EMULATOR_HOST FIREBASE_AUTH_EMULATOR_HOST FIREBASE_STORAGE_EMULATOR_HOST FIREBASE_DATABASE_EMULATOR_HOST FIREBASE_FUNCTIONS_EMULATOR_HOST; export NEXT_PUBLIC_USE_EMULATORS=false; exec next dev'",
 		"build": "next build",
 		"start": "next start",
 		"lint": "next lint"

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -68,7 +68,7 @@ function MyApp({ Component, pageProps }) {
 				<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-        <link rel="manifest" href="/site.webmanifest" />
+        <link rel="manifest" href="/manifest.json" />
 				<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 			</Head>
 			<ThemeProvider value={style}>

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -13,10 +13,12 @@ cleanup() {
 # Set the trap to call the cleanup function on script exit (Ctrl + C)
 trap cleanup EXIT
 
-# Start the Firebase Emulator and import the test data in the background
+# Start the Firebase Emulator and import the test data in the background.
+# Omit the Hosting emulator: it runs its own Next dev server (e.g. :5002) and
+# conflicts with `next dev` on :3000, and browsing that URL hits API-key referrer blocks.
 echo "Starting Firebase Emulators with imported test data..."
 export NEXT_PUBLIC_USE_EMULATORS=true
-firebase emulators:start --import=./emulator-data &
+firebase emulators:start --import=./emulator-data --only auth,functions,firestore,storage,extensions &
 
 # Save the PID of the Firebase emulator process
 EMULATOR_PID=$!
@@ -26,6 +28,9 @@ sleep 20
 
 # Start the Next.js development server
 echo "Starting Next.js development server..."
+echo ""
+echo ">>> Open the app at http://localhost:3000 (not the Hosting emulator URL)."
+echo ""
 npx next dev
 
 # Wait for the Next.js server to exit before continuing

--- a/technicalDocumentation.md
+++ b/technicalDocumentation.md
@@ -32,7 +32,7 @@ npm
 npm run dev
 ```
 
-Visit http://localhost:3000 to view your application.
+Visit http://localhost:3000 to view your application. Use that URL only for the app UI during local development; the Firebase Hosting emulator may show another port, but that origin can be blocked by API key HTTP referrer restrictions and should not be used as your main browser entry point.
 
 ### Useful Development Tools
 


### PR DESCRIPTION
`npm run dev` was easy to get into a bad state: Hosting emulator vs `next dev` on different ports, API key referrer issues, leftover `*_EMULATOR_HOST` env vars when you wanted real Firebase, flaky Firestore in dev, and App Check blocking localhost. This branch tightens the dev scripts, emulator startup, and Firebase client init so local development has one clear entry point (`http://localhost:3000`) and clearer paths for emulator vs live backends.

**Changes**

- **`start-dev.sh`**: Start only `auth`, `functions`, `firestore`, `storage`, `extensions` emulators (skip Hosting) to avoid a second Next server and referrer/API-key confusion; remind devs to use port 3000.
- **`package.json`**: `dev:live` runs plain `next dev` with emulator env vars unset and `NEXT_PUBLIC_USE_EMULATORS=false`; add `dev:turbo` as an alias of `npm run dev`.
- **`config/firebase.js`**: Gate emulator wiring on `NEXT_PUBLIC_USE_EMULATORS`; connect Auth/Firestore emulators once (globals); use `initializeFirestore` with long-polling auto-detect in the browser when not on emulators; App Check debug token defaults to Firebase’s console flow when unset in live local dev; Storage/Functions emulator hooks after instances exist.
- **`next.config.js`**: When using emulators, allow local images from emulators via `dangerouslyAllowLocalIP`.
- **`pages/_app.js`**: Point the web manifest link at `/manifest.json`.
- **`components/profile/SwitchRead.jsx`**: Remove invalid `app` import from `firebase/firestore`.
- **`functions`**: Bump `firebase-functions` to `^7.2.5` and refresh `functions/package-lock.json`.
- **Root `package-lock.json`**: Lockfile updates aligned with dependency changes.
- **`README.md`** / **`technicalDocumentation.md`**: Document the above (when to use `dev` vs `dev:live`, App Check debug tokens, localhost:3000 as the app URL).
