### PR TITLE
chore(ci): bump actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       NEXT_PUBLIC_APP_URL: https://ci.example.com
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Upgrade npm to 11 (match Firebase App Hosting)
         run: npm install -g npm@11


### PR DESCRIPTION
## Summary

GH Actions flagged that `actions/checkout@v4` runs on Node 20 internally and will be forced to Node 24 by **2026-09-16**. v6 ships with Node 24 support and is the current stable. One-line bump, no behavior change.

## Changes

- `.github/workflows/build.yml`: `actions/checkout@v4` → `actions/checkout@v6`

## Test plan

- [ ] `build` check on this PR is green (proves v6 still does what we need)