### PR TITLE
Chore/reports table formatting

### DIFF
--- a/components/reports/ReportsSection.jsx
+++ b/components/reports/ReportsSection.jsx
@@ -1102,7 +1102,7 @@ const ReportsSection = ({
 		<>
 			<Card className="w-full mt-4">
 				<CardHeader floated={false} shadow={false} className="rounded-none">
-					<div className="flex items-center justify-between gap-8 mb-8">
+					<div className="card-header--top flex items-center justify-between gap-8 mb-8">
 						<Typography variant="h5" color="blue" className="basis-1/3">
 							List of Reports
 						</Typography>
@@ -1170,7 +1170,7 @@ const ReportsSection = ({
 							</Tooltip>
 						</div>
 					</div>
-					<div className="flex items-center justify-between gap-8">
+					<div className="card-header--bottom flex items-center justify-between gap-8">
 						<TableFilterControls
 							readFilter={readFilter}
 							onReadFilterChange={setReadFilter}
@@ -1178,7 +1178,8 @@ const ReportsSection = ({
 							refresh={refresh}
 							showCheckmark={showCheckmark}
 						/>
-							<div className="flex items-center gap-2 md:gap-4">
+						{!isAgency && (
+							<div className="agency-filter flex items-center gap-2 md:gap-4">
 								<select
 									value={agencyFilter}
 									onChange={(e) => setAgencyFilter(e.target.value)}
@@ -1191,6 +1192,7 @@ const ReportsSection = ({
 									))}
 								</select>
 							</div>
+						)}
 						<div className="w-full md:w-72 basis-1/3">
 							<Input
 								label="Search"

--- a/components/table/TableBody.jsx
+++ b/components/table/TableBody.jsx
@@ -21,7 +21,7 @@ const TableBody = ({
     <tbody>
       {loadedReports.length === 0 ? (
         <tr>
-          <td colSpan="7" className="text-center">
+          <td colSpan={columns.length} className="text-center">
             No reports
           </td>
         </tr>


### PR DESCRIPTION
The reports table header was hard to target for styling, the empty row always spanned 7 columns (wrong when the column set changes), and agency users still saw an agency filter that doesn’t apply to them. This branch adds clearer header classes, hides the agency filter for agency views, and makes the “No reports” row span the real column count.

**Changes**

- **`ReportsSection.jsx`:** Add `card-header--top` / `card-header--bottom` / `agency-filter` classes for layout and styling; render the agency `<select>` only when `!isAgency`.
- **`TableBody.jsx`:** Use `colSpan={columns.length}` for the empty state instead of a fixed `7` so the row lines up with the table header.