### PR TITLE
Chore/users table logic issues

### DIFF
--- a/components/admin/Users.jsx
+++ b/components/admin/Users.jsx
@@ -126,6 +126,17 @@ const getJoinedDate = (firestoreUser, authUser) => {
 	}
 }
 
+/** Stable id for a table row (Auth uid or Firestore mobileUsers doc id). */
+const getUserRowIdentifier = (row) => row?.uid || row?.mobileUserId || row?.id
+
+/** Returns a new list with the row matching `docId` shallow-merged with `partial`. */
+const patchUserRowInList = (prev, docId, partial) => {
+	if (!docId || !partial) return prev
+	return prev.map((row) =>
+		getUserRowIdentifier(row) === docId ? { ...row, ...partial } : row,
+	)
+}
+
 /**
  * Sorts an array of users by their join date in descending order.
  *
@@ -399,6 +410,7 @@ const Users = () => {
 		loadMore,
 		reset: resetPagination,
 		refresh: refreshUsers,
+		patchUser: patchPaginatedUser,
 	} = useUsersPagination({
 		pageSize: 50,
 		userRole: roleFilter !== 'all' ? roleFilter : null,
@@ -1206,6 +1218,24 @@ const Users = () => {
 					// Handle error if needed
 				}
 			}
+		}
+
+		const optimisticPatch = {
+			...serializedAdditionalFields,
+			name,
+			email,
+			isBanned: banned,
+			userRole,
+		}
+		if (customClaims.agency) {
+			setAgencyUsers((prev) => patchUserRowInList(prev, userId, optimisticPatch))
+		} else if (customClaims.admin) {
+			patchPaginatedUser(userId, optimisticPatch)
+			setEnhancedPaginatedUsers((prev) =>
+				prev.length === 0
+					? prev
+					: patchUserRowInList(prev, userId, optimisticPatch),
+			)
 		}
 
 		// Close modal and trigger data refresh

--- a/components/admin/Users.jsx
+++ b/components/admin/Users.jsx
@@ -1211,23 +1211,6 @@ const Users = () => {
 		// Close modal and trigger data refresh
 		setUserEditModal(false)
 		setUpdate(!update) // This will trigger getData() via useEffect, refreshing the user list
-		// Update the loadedMobileUsers state after successful update
-		setLoadedMobileUsers((prevUsers) =>
-			prevUsers.map((userObj) => {
-				const identifier = userObj?.uid || userObj?.mobileUserId || userObj?.id
-				if (identifier !== userId) {
-					return userObj
-				}
-				return {
-					...userObj,
-					...serializedAdditionalFields,
-					name: name,
-					email: email,
-					isBanned: banned,
-					userRole: userRole,
-				}
-			}),
-		)
 	}
 
 	/**

--- a/hooks/useUsersPagination.jsx
+++ b/hooks/useUsersPagination.jsx
@@ -165,6 +165,19 @@ export function useUsersPagination({
     }
   }, [users.length, loading, reset]);
 
+  /**
+   * Merges partial fields into one loaded user row (Firestore doc id match).
+   * Used for optimistic UI after edits without resetting pagination.
+   */
+  const patchUser = useCallback((mobileUserDocId, partial) => {
+    if (!mobileUserDocId || !partial) return;
+    setUsers((prev) =>
+      prev.map((u) =>
+        u.id === mobileUserDocId ? { ...u, ...partial } : u
+      )
+    );
+  }, []);
+
   // Auto-load first batch on mount if autoLoad is true
   useEffect(() => {
     if (autoLoad && users.length === 0) {
@@ -207,6 +220,7 @@ export function useUsersPagination({
     reset,
     refresh,
     loadInitial,
+    patchUser,
   };
 }
 


### PR DESCRIPTION
The users table didn’t always reflect edits right away: updates only touched `loadedMobileUsers`, so admins on the paginated list and agency-scoped lists could see stale rows until a full refresh. This branch applies the same edited fields optimistically to the right list (paginated hook state, enhanced list, or agency users) and drops the redundant mobile-only path.

**Changes**

- **`Users.jsx`:** Add `getUserRowIdentifier` and `patchUserRowInList` to match rows by Auth uid or Firestore id; on successful edit, merge an optimistic patch into `agencyUsers` (agency), or call pagination `patchUser` plus `enhancedPaginatedUsers` (admin); remove the post-edit `setLoadedMobileUsers` map that didn’t cover those cases.
- **`useUsersPagination.jsx`:** Expose `patchUser` to shallow-merge fields into one loaded row by Firestore doc id so the table updates without resetting pagination or waiting on `getData()`.