### PR TITLE
fix(deps): pin Rollup macOS natives for M1 and npm optional-deps bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ First step! Clone this repo into a local directory (ex. `~/username/sites/`) on 
 
 Production builds (GitHub Actions CI and [Firebase App Hosting](https://firebase.google.com/docs/app-hosting)) use **Node 20.20.0** and **npm 11**. The repo pins this in `.nvmrc` and `package.json` `engines`; with `engine-strict=true` in `.npmrc`, `npm install` refuses other versions. Use [nvm](https://github.com/nvm-sh/nvm): `nvm install` / `nvm use` in the project root (reads `.nvmrc`), then `npm install -g npm@11` once. See [Deployment](#deployment) for the full toolchain.
 
+**Apple Silicon (M1 / M2 / M3):** install the **arm64** Node build, not the x64/Rosetta one. Check with `node -p process.arch` — it should print `arm64`. If you see `x64`, Rollup and Next may look for `@rollup/rollup-darwin-x64` / `@next/swc-darwin-x64` and you can hit missing native module errors. Reinstall Node for Apple Silicon (or turn off “Open using Rosetta” for Terminal) and run `rm -rf node_modules && npm ci` again. The repo also lists `@rollup/rollup-darwin-arm64` and `@rollup/rollup-darwin-x64` as **optionalDependencies** so npm still installs the right macOS binary even when nested optional deps mis-resolve.
+
 #### npm
 From the root of the project install dependencies by running:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,12 @@
 				"webpack": "^5.106.2"
 			},
 			"engines": {
-				"node": "20.x"
+				"node": "20.20.0",
+				"npm": ">=11.0.0"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-darwin-arm64": "4.60.3",
+				"@rollup/rollup-darwin-x64": "4.60.3"
 			}
 		},
 		"node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,10 @@
 		"tailwindcss": "^3.4.3",
 		"webpack": "^5.106.2"
 	},
+	"optionalDependencies": {
+		"@rollup/rollup-darwin-arm64": "4.60.3",
+		"@rollup/rollup-darwin-x64": "4.60.3"
+	},
 	"engines": {
 		"node": "20.20.0",
 		"npm": ">=11.0.0"

--- a/technicalDocumentation.md
+++ b/technicalDocumentation.md
@@ -174,6 +174,10 @@ docker run --rm -v "$(pwd):/workspace" -w /workspace node:20.20.0 \
 
 Then commit and push `package-lock.json`. The PR's `build` check will catch any remaining mismatch before merge.
 
+#### macOS native modules (Rollup / Apple Silicon)
+
+`package.json` lists `@rollup/rollup-darwin-arm64` and `@rollup/rollup-darwin-x64` as **optionalDependencies** (pinned to the same major as the nested `rollup` used by `@sentry/nextjs`) so macOS installs get the correct native Rollup binary even when npm mishandles nested optional dependencies ([npm CLI issue #4828](https://github.com/npm/cli/issues/4828)). On Apple Silicon, use **arm64** Node (`node -p process.arch` should print `arm64`); if it prints `x64`, you are likely on Rosetta and builds may look for the wrong native packages.
+
 #### Where things live
 
 | Thing | Where |


### PR DESCRIPTION
## Summary

`next build --webpack` was failing with **Cannot find module `@rollup/rollup-darwin-x64`** (or arm64) when Rollup is pulled in through **@sentry/nextjs** — a known **npm optional dependency** resolution gap ([npm/cli#4828](https://github.com/npm/cli/issues/4828)).

On **Apple Silicon**, the long-term fix is also to run **arm64** Node (`node -p process.arch` → `arm64`), not Rosetta **x64** Node, so the toolchain asks for the right native packages. This PR adds a **dependency-level safety net** plus docs so M1 devs are not blocked even when npm mis-resolves nested optionals.

## Changes

- **`package.json`** — root `optionalDependencies` for `@rollup/rollup-darwin-arm64` and `@rollup/rollup-darwin-x64` pinned to **4.60.3** (same as the nested `rollup` version in the lockfile).
- **`package-lock.json`** — regenerated with **Node 20.20.0 + npm 11** (Docker) so CI/App Hosting stay aligned.
- **`README.md`** — Apple Silicon / Rosetta note under Node version.
- **`technicalDocumentation.md`** — short subsection under the deployment pipeline about Rollup macOS natives and arm64 vs x64 Node.

## Test plan

- [ ] `build` GitHub Action passes on this PR
- [ ] On an M1 Mac with arm64 Node 20.20 + npm 11: `rm -rf node_modules && npm ci && npm run build` succeeds