### PR TITLE
Bug/users-table-duplicates

### DIFF
--- a/components/admin/Users.jsx
+++ b/components/admin/Users.jsx
@@ -428,6 +428,8 @@ const Users = () => {
 	const [enhancedPaginatedUsers, setEnhancedPaginatedUsers] = useState([])
 	const paginatedUsersRef = useRef(paginatedUsers)
 	paginatedUsersRef.current = paginatedUsers
+	// Skip update-effect on mount; mount effect already loads data
+	const skipUpdateRefreshOnMount = useRef(true)
 
 	// Processed users: combines pagination data with auth details and applies search
 	const loadedMobileUsers = useMemo(() => {
@@ -604,10 +606,8 @@ const Users = () => {
 				setAgencyUsers(sortByJoinedDate(filteredUsers) || [])
 				setAgencyLoading(false)
 			} else {
-				// Admin user - use pagination hook
-				// The pagination hook will handle the initial load
-				// We just need to trigger it
-				loadMore()
+				// Admin: replace list (do not append — avoids duplicate rows on refresh)
+				await resetPagination()
 			}
 		} catch (error) {
 			console.error('Failed to fetch or process user data:', error)
@@ -1259,6 +1259,10 @@ const Users = () => {
 	 * @dependency {boolean} update - The state that triggers the data fetching when it changes.
 	 */
 	useEffect(() => {
+		if (skipUpdateRefreshOnMount.current) {
+			skipUpdateRefreshOnMount.current = false
+			return
+		}
 		getData()
 	}, [update])
 
@@ -1384,13 +1388,13 @@ const Users = () => {
 										</tr>
 									) : (
 										// Render user rows with role-based conditional rendering
-										loadedMobileUsers.map((userObj, key) => {
+										loadedMobileUsers.map((userObj) => {
 											// Extract user ID for operations
 											let userId = userObj.mobileUserId ?? userObj.id ?? userObj.uid
 											return (
 												<tr
 													className={`border-b transition duration-300 ease-in-out dark:border-indigo-100 ${!customClaims.agency && !userObj.hasFirestoreDoc && 'bg-red-50'} ${userObj.disabled && 'bg-yellow-100'}`}
-													key={`${userId ?? 'unknown'}-${key}`}
+													key={userId ?? userObj.email}
 													onClick={
 														customClaims.admin
 															? () => handleEditUser(userObj, userId)

--- a/components/admin/Users.jsx
+++ b/components/admin/Users.jsx
@@ -1388,13 +1388,13 @@ const Users = () => {
 										</tr>
 									) : (
 										// Render user rows with role-based conditional rendering
-										loadedMobileUsers.map((userObj) => {
+										loadedMobileUsers.map((userObj, index) => {
 											// Extract user ID for operations
 											let userId = userObj.mobileUserId ?? userObj.id ?? userObj.uid
 											return (
 												<tr
 													className={`border-b transition duration-300 ease-in-out dark:border-indigo-100 ${!customClaims.agency && !userObj.hasFirestoreDoc && 'bg-red-50'} ${userObj.disabled && 'bg-yellow-100'}`}
-													key={userId ?? userObj.email}
+													key={userId ?? userObj.email ?? `unknown-${index}`}
 													onClick={
 														customClaims.admin
 															? () => handleEditUser(userObj, userId)

--- a/components/reports/ReportsSection.jsx
+++ b/components/reports/ReportsSection.jsx
@@ -1234,7 +1234,7 @@ const ReportsSection = ({
 								customClaims.admin ? setIncludeArchived : undefined
 							}
 						/>
-						<div className="flex flex-row items-center gap-1">
+						<div className="flex flex-row items-center gap-2">
 							<TableDropdownMenu
 								reportWeek={reportWeek}
 								onChange={(value) => setReportWeek(value)} // Update `reportWeek` based on selection

--- a/components/table/TableDropdownMenu.jsx
+++ b/components/table/TableDropdownMenu.jsx
@@ -186,7 +186,7 @@ export function TableDropdownMenu({
 	}
 
 	return (
-		<div className='flex flex-row'>
+		<div className='flex flex-row gap-2'>
 			{onAgencyChange && (
 				<Menu open={openAgencyMenu} handler={setOpenAgencyMenu}>
 					<MenuHandler>

--- a/hooks/useUsersPagination.jsx
+++ b/hooks/useUsersPagination.jsx
@@ -1,6 +1,14 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { fetchUsersBatch, fetchUserDetailsBatch } from '../utils/firebase-helpers';
 
+/** @param {Array<{ id?: string }>} prev @param {Array<{ id?: string }>} incoming */
+function appendUsersWithoutDuplicates(prev, incoming) {
+  if (!incoming.length) return prev;
+  const seen = new Set(prev.map((u) => u.id).filter(Boolean));
+  const unique = incoming.filter((u) => u.id && !seen.has(u.id));
+  return unique.length ? [...prev, ...unique] : prev;
+}
+
 /**
  * Custom hook for paginated user fetching with infinite scroll support
  *
@@ -39,16 +47,17 @@ export function useUsersPagination({
     orderField,
     orderDirection,
   });
+  const loadingRef = useRef(false);
 
   /**
    * Loads the next batch of users
    */
   const loadMore = useCallback(async () => {
-    // Prevent loading if already loading or no more data
-    if (loading || !hasMore) {
+    if (loadingRef.current || !hasMore) {
       return;
     }
 
+    loadingRef.current = true;
     try {
       setLoading(true);
       setError(null);
@@ -63,19 +72,18 @@ export function useUsersPagination({
         orderDirection,
       });
 
-      // Append new users to existing list
-      setUsers((prev) => [...prev, ...result.users]);
+      setUsers((prev) => appendUsersWithoutDuplicates(prev, result.users));
       setLastDoc(result.lastDoc);
       setHasMore(result.hasMore);
     } catch (err) {
       console.error('Error loading more users:', err);
       setError(err.message || 'Failed to load users');
     } finally {
+      loadingRef.current = false;
       setLoading(false);
       setInitialLoading(false);
     }
   }, [
-    loading,
     hasMore,
     pageSize,
     lastDoc,
@@ -91,6 +99,11 @@ export function useUsersPagination({
    * Useful when filters/search changes
    */
   const reset = useCallback(async () => {
+    if (loadingRef.current) {
+      return;
+    }
+
+    loadingRef.current = true;
     setUsers([]);
     setLastDoc(null);
     setHasMore(true);
@@ -117,6 +130,7 @@ export function useUsersPagination({
       console.error('Error resetting pagination:', err);
       setError(err.message || 'Failed to load users');
     } finally {
+      loadingRef.current = false;
       setLoading(false);
       setInitialLoading(false);
     }
@@ -160,10 +174,10 @@ export function useUsersPagination({
    * Manually loads first batch (for when autoLoad is false)
    */
   const loadInitial = useCallback(() => {
-    if (users.length === 0 && !loading) {
+    if (users.length === 0 && !loadingRef.current) {
       reset();
     }
-  }, [users.length, loading, reset]);
+  }, [users.length, reset]);
 
   /**
    * Merges partial fields into one loaded user row (Firestore doc id match).


### PR DESCRIPTION
The admin Users table was showing the same people multiple times (e.g. 3 users repeated as 12 rows). The data in Firestore was fine — the first page was being fetched and **appended** several times on load and refresh because of overlapping `loadMore()` calls and two effects both triggering a fetch on mount.

This PR resets the list on admin refresh, skips the redundant mount fetch, and hardens the pagination hook so concurrent loads can’t duplicate the first batch.

## Changes

- **`hooks/useUsersPagination.jsx`** — Use a `loadingRef` to block overlapping fetches; dedupe by Firestore `id` when appending in `loadMore`
- **`components/admin/Users.jsx`** — Admin `getData()` calls `resetPagination()` instead of `loadMore()` so refreshes replace the list
- **`components/admin/Users.jsx`** — Skip the `[update]` effect on first mount (mount effect already loads data)
- **`components/admin/Users.jsx`** — Use stable row keys (`userId` / `email`) instead of index-based keys
- **`components/reports/ReportsSection.jsx`** / **`components/table/TableDropdownMenu.jsx`** — Minor spacing tweaks (`gap-1` → `gap-2`) — unrelated to the users bug; consider dropping from this PR if you want a single-purpose branch

## Test plan

- [ ] Open **Users** as admin — each user appears once; total count matches real user count
- [ ] Hard refresh the page — no duplicate rows
- [ ] Edit a user and save — list refreshes without duplicates
- [ ] Delete a user — list refreshes without duplicates
- [ ] If you have 50+ users, scroll to load more — additional users append correctly with no repeats
- [ ] Log in as an agency user — agency user list still loads normally