### PR TITLE
fix(reports): use next/link in ViewReport for uploaded images

### DIFF
--- a/components/partials/report/ViewReport.jsx
+++ b/components/partials/report/ViewReport.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { Card, Link, Button, Typography } from '@material-tailwind/react'
-import { useTranslation } from 'next-i18next' // Import the useTranslation hook
+import Link from 'next/link'
+import { Card, Button, Typography } from '@material-tailwind/react'
+import { useTranslation } from 'next-i18next'
 import globalStyles from '../../../styles/globalStyles'
 import Image from 'next/image'
 
@@ -49,21 +50,22 @@ const ViewReport = ({
 						{t('image')}
 					</Typography>
 					<div className="flex w-full overflow-y-auto">
-						{imageURLs.map((image, i = self.crypto.randomUUID()) => {
-							return (
-								<div className="flex mr-2" key={i}>
-									<Link href={image} target="_blank">
-										<Image
-											src={image}
-											width={100}
-											height={100}
-											alt="image"
-											className="object-cover w-auto"
-										/>
-									</Link>
-								</div>
-							)
-						})}
+						{imageURLs.map((image, index) => (
+							<div className="flex mr-2" key={index}>
+								<Link
+									href={image}
+									target="_blank"
+									rel="noopener noreferrer">
+									<Image
+										src={image}
+										width={100}
+										height={100}
+										alt="image"
+										className="object-cover w-auto"
+									/>
+								</Link>
+							</div>
+						))}
 					</div>
 				</div>
 				{/* Details */}


### PR DESCRIPTION
## Summary

General users hit a client-side crash after submitting a report on `/report` when the report included uploaded images. The success view (`ViewReport`) imported `Link` from `@material-tailwind/react`, but that package does not export a Link component — so React tried to render `undefined` and the page blew up.

This restores `next/link` (matching the pre-refactor inline code and `ReviewStep`) and cleans up image list keys.

## Changes

- Import `Link` from `next/link` instead of Material Tailwind in `ViewReport.jsx`
- Use stable index keys in the image map
- Add `rel="noopener noreferrer"` on external image links

## Test plan

- [ ] Log in as a general user (not admin/agency)
- [ ] Complete the `/report` flow and submit **with at least one image**
- [ ] Confirm the post-submit success view renders instead of the Next.js application error
- [ ] Click through uploaded image thumbnails (open in new tab)
- [ ] Submit a report **without** images and confirm success view still works
- [ ] Wait for green **`build`** check before merge