### PR TITLE
Feat/tag defaults bilingual labels

### DIFF
--- a/components/admin/TagDefaultsSettings.jsx
+++ b/components/admin/TagDefaultsSettings.jsx
@@ -1,6 +1,6 @@
 /**
- * Admin UI for editing global Topic/Source tag defaults.
- * Saves to tagSystems/defaults and propagates required tags to all agencies.
+ * Admin UI for editing global Topic/Source tag defaults with EN/ES labels.
+ * Saves to tagSystems/defaults and propagates required ids to all agencies.
  */
 
 import React, { useCallback, useEffect, useState } from 'react'
@@ -14,101 +14,141 @@ import FormInput from '../ui/FormInput'
 import ConfirmModal from '../modals/common/ConfirmModal'
 import { maxActiveTags } from '../../config/tagSystems'
 import {
-	ensureOtherInRequired,
+	TAG_ID_MAX_LENGTH,
+	TAG_LABEL_MAX_LENGTH,
+	ensureOtherInLabeledRequired,
 	fetchTagDefaults,
 	isOtherTagName,
+	normalizeOtherAliasesForAllAgencies,
 	saveAndPropagateTagDefaults,
+	validateLabeledTag,
 	validateTagDefaults,
 } from '../../utils/tag-defaults'
 
 const MAX_ACTIVE_TOPICS = maxActiveTags[1]
 const MAX_ACTIVE_SOURCES = maxActiveTags[2]
-const TAG_MAX_LENGTH = 20
+
+const emptyDraft = () => ({
+	id: '',
+	labels: { en: '', es: '' },
+})
 
 /**
- * One required-tag list editor (Topic or Source).
+ * One required-tag list editor (Topic or Source) with bilingual labels.
  *
  * @param {{
  *   title: string,
  *   maxActive: number,
- *   tags: string[],
- *   setTags: (next: string[]) => void,
+ *   tags: import('../../utils/tag-defaults').LabeledTag[],
+ *   setTags: (next: import('../../utils/tag-defaults').LabeledTag[]) => void,
  * }} props
  */
 function RequiredTagListEditor({ title, maxActive, tags, setTags }) {
-	const [draft, setDraft] = useState('')
-	const [editing, setEditing] = useState(null)
-	const [editValue, setEditValue] = useState('')
+	const [draft, setDraft] = useState(emptyDraft)
+	const [editingId, setEditingId] = useState(null)
+	const [editValue, setEditValue] = useState(emptyDraft)
 	const [localError, setLocalError] = useState('')
 
 	const handleAdd = (e) => {
 		e.preventDefault()
-		const value = draft.trim()
-		if (!value) return
-		if (value.length > TAG_MAX_LENGTH) {
-			setLocalError(`Tags cannot exceed ${TAG_MAX_LENGTH} characters.`)
+		const entry = {
+			id: draft.id.trim(),
+			labels: {
+				en: draft.labels.en.trim(),
+				es: draft.labels.es.trim(),
+			},
+		}
+		const check = validateLabeledTag(entry)
+		if (!check.ok) {
+			setLocalError(check.error || 'Invalid tag.')
 			return
 		}
-		if (isOtherTagName(value)) {
+		if (isOtherTagName(entry.id)) {
 			setLocalError('Other is already included and cannot be added again.')
 			return
 		}
-		const withoutOther = tags.filter((t) => !isOtherTagName(t))
-		if (withoutOther.some((t) => t.toLowerCase() === value.toLowerCase())) {
-			setLocalError('This tag already exists.')
+		const withoutOther = tags.filter((t) => !isOtherTagName(t.id))
+		if (
+			withoutOther.some(
+				(t) => t.id.toLowerCase() === entry.id.toLowerCase(),
+			)
+		) {
+			setLocalError('This tag id already exists.')
 			return
 		}
 		if (tags.length >= maxActive) {
 			setLocalError(`Maximum ${maxActive} defaults (including Other).`)
 			return
 		}
-		setTags(ensureOtherInRequired([...withoutOther, value]))
-		setDraft('')
+		setTags(ensureOtherInLabeledRequired([...withoutOther, entry]))
+		setDraft(emptyDraft())
 		setLocalError('')
 	}
 
-	const handleRemove = (tag) => {
-		if (isOtherTagName(tag)) return
-		setTags(ensureOtherInRequired(tags.filter((t) => t !== tag)))
+	const handleRemove = (tagId) => {
+		if (isOtherTagName(tagId)) return
+		setTags(
+			ensureOtherInLabeledRequired(tags.filter((t) => t.id !== tagId)),
+		)
 		setLocalError('')
 	}
 
-	const startRename = (tag) => {
-		if (isOtherTagName(tag)) return
-		setEditing(tag)
-		setEditValue(tag)
+	const startEdit = (tag) => {
+		setEditingId(tag.id)
+		setEditValue({
+			id: tag.id,
+			labels: { en: tag.labels.en, es: tag.labels.es },
+		})
 		setLocalError('')
 	}
 
-	const commitRename = (e) => {
+	const commitEdit = (e) => {
 		e.preventDefault()
-		if (!editing) return
-		const value = editValue.trim()
-		if (!value || isOtherTagName(value)) {
-			setLocalError('Invalid tag name.')
+		if (!editingId) return
+		const locked = isOtherTagName(editingId)
+		const entry = {
+			id: locked ? 'Other' : editValue.id.trim(),
+			labels: {
+				en: editValue.labels.en.trim(),
+				es: editValue.labels.es.trim(),
+			},
+		}
+		const check = validateLabeledTag(entry)
+		if (!check.ok) {
+			setLocalError(check.error || 'Invalid tag.')
 			return
 		}
-		if (value.length > TAG_MAX_LENGTH) {
-			setLocalError(`Tags cannot exceed ${TAG_MAX_LENGTH} characters.`)
+		if (!locked && isOtherTagName(entry.id)) {
+			setLocalError('Cannot rename a tag to Other.')
 			return
 		}
 		const conflict = tags.some(
-			(t) => t !== editing && t.toLowerCase() === value.toLowerCase(),
+			(t) =>
+				t.id !== editingId &&
+				t.id.toLowerCase() === entry.id.toLowerCase(),
 		)
 		if (conflict) {
-			setLocalError('This tag already exists.')
+			setLocalError('This tag id already exists.')
 			return
 		}
+		if (!locked && entry.id !== editingId) {
+			const ok = window.confirm(
+				`Change id from "${editingId}" to "${entry.id}"?\n\nExisting agency tag lists and reports still using the old id will not be remapped automatically.`,
+			)
+			if (!ok) return
+		}
 		setTags(
-			ensureOtherInRequired(tags.map((t) => (t === editing ? value : t))),
+			ensureOtherInLabeledRequired(
+				tags.map((t) => (t.id === editingId ? entry : t)),
+			),
 		)
-		setEditing(null)
-		setEditValue('')
+		setEditingId(null)
+		setEditValue(emptyDraft())
 		setLocalError('')
 	}
 
 	return (
-		<div className="flex-1 min-w-[240px]">
+		<div className="flex-1 min-w-[280px]">
 			<div className="flex items-baseline justify-between gap-2 mb-2">
 				<div className="font-medium text-blue-600">{title}</div>
 				<div className="text-xs text-gray-500">
@@ -116,79 +156,170 @@ function RequiredTagListEditor({ title, maxActive, tags, setTags }) {
 				</div>
 			</div>
 
-			<ul className="mb-3 space-y-1">
+			<ul className="mb-3 space-y-2">
 				{tags.map((tag) => {
-					const locked = isOtherTagName(tag)
-					if (editing === tag) {
+					const locked = isOtherTagName(tag.id)
+					if (editingId === tag.id) {
 						return (
-							<li key={tag} className="flex items-center gap-2">
+							<li
+								key={tag.id}
+								className="rounded-lg bg-blue-gray-50 p-3">
 								<form
-									onSubmit={commitRename}
-									className="flex flex-1 items-center gap-2">
+									onSubmit={commitEdit}
+									className="flex flex-col gap-2">
+									{!locked && (
+										<FormInput
+											id={`edit-id-${title}-${tag.id}`}
+											type="text"
+											label="English id (stored)"
+											value={editValue.id}
+											onChange={(e) =>
+												setEditValue((prev) => ({
+													...prev,
+													id: e.target.value,
+												}))
+											}
+											maxLength={TAG_ID_MAX_LENGTH}
+											required
+										/>
+									)}
+									{locked && (
+										<p className="text-xs text-gray-500">
+											Id: Other (locked)
+										</p>
+									)}
 									<FormInput
-										id={`edit-${title}-${tag}`}
+										id={`edit-en-${title}-${tag.id}`}
 										type="text"
-										label="Rename tag"
-										value={editValue}
-										onChange={(e) => setEditValue(e.target.value)}
+										label="Label (EN)"
+										value={editValue.labels.en}
+										onChange={(e) =>
+											setEditValue((prev) => ({
+												...prev,
+												labels: {
+													...prev.labels,
+													en: e.target.value,
+												},
+											}))
+										}
+										maxLength={TAG_LABEL_MAX_LENGTH}
 										required
 									/>
-									<Button type="submit" size="sm" color="blue">
-										Save
-									</Button>
-									<Button
-										type="button"
-										size="sm"
-										variant="outlined"
-										color="gray"
-										onClick={() => setEditing(null)}>
-										Cancel
-									</Button>
+									<FormInput
+										id={`edit-es-${title}-${tag.id}`}
+										type="text"
+										label="Label (ES)"
+										value={editValue.labels.es}
+										onChange={(e) =>
+											setEditValue((prev) => ({
+												...prev,
+												labels: {
+													...prev.labels,
+													es: e.target.value,
+												},
+											}))
+										}
+										maxLength={TAG_LABEL_MAX_LENGTH}
+										required
+									/>
+									<div className="flex gap-2">
+										<Button type="submit" size="sm" color="blue">
+											Save
+										</Button>
+										<Button
+											type="button"
+											size="sm"
+											variant="outlined"
+											color="gray"
+											onClick={() => setEditingId(null)}>
+											Cancel
+										</Button>
+									</div>
 								</form>
 							</li>
 						)
 					}
 					return (
 						<li
-							key={tag}
-							className="flex items-center justify-between gap-2 rounded-lg bg-blue-gray-50 px-3 py-2 text-sm">
-							<span>
-								{locked ? 'Other*' : tag}
-							</span>
-							{!locked && (
-								<span className="flex items-center gap-1">
-									<button
-										type="button"
-										className="text-blue-600 hover:text-blue-800 p-1"
-										aria-label={`Rename ${tag}`}
-										onClick={() => startRename(tag)}>
-										<MdModeEditOutline size={18} />
-									</button>
+							key={tag.id}
+							className="flex items-start justify-between gap-2 rounded-lg bg-blue-gray-50 px-3 py-2 text-sm">
+							<div>
+								<div className="font-medium">
+									{tag.labels.en}
+									{locked ? ' *' : ''}
+								</div>
+								<div className="text-gray-600">
+									ES: {tag.labels.es}
+								</div>
+								<div className="text-xs text-gray-400">
+									id: {tag.id}
+								</div>
+							</div>
+							<span className="flex items-center gap-1 shrink-0">
+								<button
+									type="button"
+									className="text-blue-600 hover:text-blue-800 p-1"
+									aria-label={`Edit ${tag.id}`}
+									onClick={() => startEdit(tag)}>
+									<MdModeEditOutline size={18} />
+								</button>
+								{!locked && (
 									<button
 										type="button"
 										className="text-red-500 hover:text-red-700 p-1"
-										aria-label={`Remove ${tag}`}
-										onClick={() => handleRemove(tag)}>
+										aria-label={`Remove ${tag.id}`}
+										onClick={() => handleRemove(tag.id)}>
 										<TiDelete size={20} />
 									</button>
-								</span>
-							)}
+								)}
+							</span>
 						</li>
 					)
 				})}
 			</ul>
 
-			<form onSubmit={handleAdd} className="flex items-end gap-2">
-				<div className="flex-1">
-					<FormInput
-						id={`add-${title}`}
-						type="text"
-						label={`New ${title.replace(' Default', '')}`}
-						value={draft}
-						onChange={(e) => setDraft(e.target.value)}
-					/>
-				</div>
-				<Button type="submit" size="sm" color="blue" className="flex items-center gap-1">
+			<form onSubmit={handleAdd} className="flex flex-col gap-2">
+				<FormInput
+					id={`add-id-${title}`}
+					type="text"
+					label="English id (stored)"
+					value={draft.id}
+					onChange={(e) =>
+						setDraft((prev) => ({ ...prev, id: e.target.value }))
+					}
+					maxLength={TAG_ID_MAX_LENGTH}
+				/>
+				<FormInput
+					id={`add-en-${title}`}
+					type="text"
+					label="Label (EN)"
+					value={draft.labels.en}
+					onChange={(e) =>
+						setDraft((prev) => ({
+							...prev,
+							labels: { ...prev.labels, en: e.target.value },
+						}))
+					}
+					maxLength={TAG_LABEL_MAX_LENGTH}
+				/>
+				<FormInput
+					id={`add-es-${title}`}
+					type="text"
+					label="Label (ES)"
+					value={draft.labels.es}
+					onChange={(e) =>
+						setDraft((prev) => ({
+							...prev,
+							labels: { ...prev.labels, es: e.target.value },
+						}))
+					}
+					maxLength={TAG_LABEL_MAX_LENGTH}
+				/>
+				<Button
+					type="submit"
+					size="sm"
+					color="blue"
+					className="flex items-center gap-1 self-start">
 					<FaPlus size={12} /> Add
 				</Button>
 			</form>
@@ -213,6 +344,7 @@ const TagDefaultsSettings = () => {
 	const [status, setStatus] = useState('')
 	const [error, setError] = useState('')
 	const [confirmOpen, setConfirmOpen] = useState(false)
+	const [normalizeConfirmOpen, setNormalizeConfirmOpen] = useState(false)
 
 	const loadDefaults = useCallback(async () => {
 		setLoading(true)
@@ -267,6 +399,25 @@ const TagDefaultsSettings = () => {
 		}
 	}
 
+	const handleConfirmNormalize = async () => {
+		setNormalizeConfirmOpen(false)
+		setBusy(true)
+		setStatus('')
+		setError('')
+		try {
+			const { updated, scanned } =
+				await normalizeOtherAliasesForAllAgencies()
+			setStatus(
+				`Normalized Other aliases on ${updated} of ${scanned} agency tag document(s).`,
+			)
+		} catch (err) {
+			console.error(err)
+			setError(err?.message || 'Failed to normalize Other aliases.')
+		} finally {
+			setBusy(false)
+		}
+	}
+
 	if (loading) {
 		return (
 			<div className="mb-8 p-4 bg-white rounded-lg border border-blue-gray-100">
@@ -280,8 +431,10 @@ const TagDefaultsSettings = () => {
 			<div className={globalStyles.heading.h1.blue}>Global Tag Defaults</div>
 			<p className="text-sm text-gray-600 mb-4">
 				These Topic and Source tags are required for every newsroom. Agencies
-				cannot deactivate, rename, or remove them. Saving adds any new required
-				tags to all agencies; retired tags already on agencies are left in place.
+				cannot deactivate, rename, or remove them. Enter an English id (stored
+				in reports) plus English and Spanish display labels. Saving adds any
+				new required ids to all agencies; retired tags already on agencies are
+				left in place.
 			</p>
 
 			<div className="flex flex-col lg:flex-row gap-8 mb-4">
@@ -300,15 +453,20 @@ const TagDefaultsSettings = () => {
 			</div>
 
 			<p className="text-xs text-gray-500 mb-4">
-				* &quot;Other&quot; is a default that cannot be edited or removed.
+				* &quot;Other&quot; is required and its id cannot be changed. Both EN
+				and ES labels are required for every tag before save.
 			</p>
 
 			<div className="flex flex-wrap items-center gap-3">
+				<Button color="blue" disabled={busy} onClick={handleSaveClick}>
+					{busy ? 'Working…' : 'Save & apply to all agencies'}
+				</Button>
 				<Button
 					color="blue"
+					variant="outlined"
 					disabled={busy}
-					onClick={handleSaveClick}>
-					{busy ? 'Saving…' : 'Save & apply to all agencies'}
+					onClick={() => setNormalizeConfirmOpen(true)}>
+					Normalize Other aliases
 				</Button>
 				{status && <p className="text-sm text-green-700">{status}</p>}
 				{error && <p className="text-sm text-red-600">{error}</p>}
@@ -318,9 +476,18 @@ const TagDefaultsSettings = () => {
 				<ConfirmModal
 					func={handleConfirmSave}
 					title="Apply tag defaults?"
-					subtitle="This will add these required tags to all agencies. Existing custom or retired tags are kept."
+					subtitle="This will add these required tag ids to all agencies and save EN/ES labels. Existing custom or retired tags are kept."
 					CTA="Apply"
 					closeModal={setConfirmOpen}
+				/>
+			)}
+			{normalizeConfirmOpen && (
+				<ConfirmModal
+					func={handleConfirmNormalize}
+					title="Normalize Other aliases?"
+					subtitle="This removes legacy Other/Otro (and similar) from every agency Topic/Source list and active tags, leaving a single Other. Safe to run more than once."
+					CTA="Normalize"
+					closeModal={setNormalizeConfirmOpen}
 				/>
 			)}
 		</div>

--- a/components/analytics/TagSystem.jsx
+++ b/components/analytics/TagSystem.jsx
@@ -37,6 +37,7 @@ import {
 import {
 	buildAgencyTagsPayload,
 	fetchTagDefaults,
+	getRequiredIds,
 	isOtherTagName,
 	isRequiredTag,
 } from '../../utils/tag-defaults'
@@ -141,9 +142,9 @@ const TagSystem = ({ tagSystem, setTagSystem, agencyID }) => {
 
 		const defaults = await fetchTagDefaults()
 		if (tagSystem === 1) {
-			setRequiredTags(defaults.Topic.required)
+			setRequiredTags(getRequiredIds(defaults, 'Topic'))
 		} else if (tagSystem === 2) {
-			setRequiredTags(defaults.Source.required)
+			setRequiredTags(getRequiredIds(defaults, 'Source'))
 		} else {
 			setRequiredTags([])
 		}

--- a/components/analytics/TagSystem.jsx
+++ b/components/analytics/TagSystem.jsx
@@ -36,15 +36,22 @@ import {
 } from '../../utils/label-tags'
 import {
 	buildAgencyTagsPayload,
+	buildTagLabelMap,
+	canonicalizeTagId,
 	fetchTagDefaults,
 	getRequiredIds,
+	getTagLabel,
 	isOtherTagName,
 	isRequiredTag,
+	mergeTagLabelMaps,
+	normalizeAgencyLabelMap,
+	removeAgencyTagFromLabelMap,
+	renameAgencyTagInLabelMap,
 } from '../../utils/tag-defaults'
 
 const maxTags = maxActiveTags
 
-const setData = async (tagSystem, list, active, agency) => {
+const setData = async (tagSystem, list, active, agency, labels) => {
 	const docRef = doc(db, 'tags', agency)
 	const docSnap = await getDoc(docRef)
 	const key = tagSystems[tagSystem]
@@ -59,11 +66,15 @@ const setData = async (tagSystem, list, active, agency) => {
 				...existingSlice,
 				list,
 				active,
+				...(tagSystem === 3 ? {} : { labels: labels || {} }),
 			},
 		})
 	} else {
 		await setDoc(doc(db, 'tags', agency), {
-			[key]: { list, active },
+			[key]:
+				tagSystem === 3
+					? { list, active }
+					: { list, active, labels: labels || {} },
 		})
 	}
 }
@@ -71,6 +82,8 @@ const setData = async (tagSystem, list, active, agency) => {
 const TagSystem = ({ tagSystem, setTagSystem, agencyID }) => {
 	const [list, setList] = useState([])
 	const [active, setActive] = useState([])
+	const [tagLabels, setTagLabels] = useState({})
+	const [defaultsLabelMap, setDefaultsLabelMap] = useState({})
 	const [labelColors, setLabelColors] = useState({})
 	const [agencyName, setAgencyName] = useState('')
 	const [requiredTags, setRequiredTags] = useState([])
@@ -120,6 +133,37 @@ const TagSystem = ({ tagSystem, setTagSystem, agencyID }) => {
 	const selectedIsRequired =
 		!isLabelsMode && selected && isRequiredTag(selected, requiredTags)
 
+	const displayLabelMap = useMemo(
+		() => mergeTagLabelMaps(defaultsLabelMap, tagLabels),
+		[defaultsLabelMap, tagLabels],
+	)
+
+	const formatTagDisplay = (item) => {
+		if (isOtherTagName(item)) return 'Other'
+		const canonical = canonicalizeTagId(item)
+		const en = getTagLabel({
+			id: item,
+			locale: 'en',
+			labelMap: displayLabelMap,
+		})
+		// Map keys are canonical; raw item may still have topics./sources. prefixes.
+		const es = displayLabelMap?.[canonical]?.es
+		const showMutedId = en !== item
+		const showEs = Boolean(es) && es !== en
+		if (!showMutedId && !showEs) return en
+		return (
+			<span className="flex flex-col items-center text-center leading-tight">
+				<span>{en}</span>
+				{showMutedId && (
+					<span className="text-xs text-gray-400 font-normal">{item}</span>
+				)}
+				{showEs && (
+					<span className="text-xs text-gray-500 font-normal">{es}</span>
+				)}
+			</span>
+		)
+	}
+
 	const applyTagsToState = (tagsData) => {
 		setList(tagsData?.list || [])
 		const activeList = [...(tagsData?.active || [])]
@@ -131,6 +175,9 @@ const TagSystem = ({ tagSystem, setTagSystem, agencyID }) => {
 		setActive(activeList)
 		if (isLabelsMode) {
 			setLabelColors(tagsData?.colors || {})
+			setTagLabels({})
+		} else {
+			setTagLabels(normalizeAgencyLabelMap(tagsData?.labels))
 		}
 	}
 
@@ -141,6 +188,7 @@ const TagSystem = ({ tagSystem, setTagSystem, agencyID }) => {
 		setAgencyName(name || '')
 
 		const defaults = await fetchTagDefaults()
+		setDefaultsLabelMap(buildTagLabelMap(defaults))
 		if (tagSystem === 1) {
 			setRequiredTags(getRequiredIds(defaults, 'Topic'))
 		} else if (tagSystem === 2) {
@@ -204,7 +252,7 @@ const TagSystem = ({ tagSystem, setTagSystem, agencyID }) => {
 				setRenameTagModal(true)
 				break
 		}
-		setData(tagSystem, list, active, agencyID)
+		setData(tagSystem, list, active, agencyID, tagLabels)
 	}
 
 	const deleteTag = () => {
@@ -214,14 +262,14 @@ const TagSystem = ({ tagSystem, setTagSystem, agencyID }) => {
 			return
 		}
 
-		if (list?.includes?.(selected)) {
-			list.splice(list.indexOf(selected), 1)
-		}
-		if (active?.includes?.(selected)) {
-			active.splice(active.indexOf(selected), 1)
-		}
+		const nextList = list.filter((t) => t !== selected)
+		const nextActive = active.filter((t) => t !== selected)
+		const nextLabels = removeAgencyTagFromLabelMap(tagLabels, selected)
+		setList(nextList)
+		setActive(nextActive)
+		setTagLabels(nextLabels)
 		setSelected('')
-		setData(tagSystem, list, active, agencyID)
+		setData(tagSystem, nextList, nextActive, agencyID, nextLabels)
 		setDeleteModal(false)
 	}
 
@@ -254,16 +302,27 @@ const TagSystem = ({ tagSystem, setTagSystem, agencyID }) => {
 		await getData(agencyID)
 	}
 
-	const replaceTag = (tag) => {
+	const replaceTag = (entry) => {
 		if (isRequiredTag(selected, requiredTags)) return
+		const newId = typeof entry === 'string' ? entry : entry?.id
+		const nextLabelsPayload =
+			typeof entry === 'string'
+				? { en: entry, es: entry }
+				: entry?.labels || { en: newId, es: newId }
+		if (!newId) return
 
-		if (list?.includes?.(selected)) {
-			list[list.indexOf(selected)] = tag
-		}
-		if (active?.includes?.(selected)) {
-			active[active.indexOf(selected)] = tag
-		}
-		setData(tagSystem, list, active, agencyID)
+		const nextList = list.map((t) => (t === selected ? newId : t))
+		const nextActive = active.map((t) => (t === selected ? newId : t))
+		const nextLabels = renameAgencyTagInLabelMap(
+			tagLabels,
+			selected,
+			newId,
+			nextLabelsPayload,
+		)
+		setList(nextList)
+		setActive(nextActive)
+		setTagLabels(nextLabels)
+		setData(tagSystem, nextList, nextActive, agencyID, nextLabels)
 		setSelected('')
 	}
 
@@ -271,23 +330,38 @@ const TagSystem = ({ tagSystem, setTagSystem, agencyID }) => {
 	 * Adds a newsroom tag to the agency catalog and turns it on immediately when
 	 * under the live-tag limit (no separate "Mark as Active" step).
 	 *
-	 * @param {string} tag - New topic or source label to append.
+	 * @param {{ id: string, labels: { en: string, es: string } }|string} entry
 	 */
-	const addNewTag = (tag) => {
-		const arr = [...list, tag]
+	const addNewTag = (entry) => {
+		const id = typeof entry === 'string' ? entry.trim() : entry?.id?.trim()
+		const labels =
+			typeof entry === 'string'
+				? { en: id, es: id }
+				: {
+						en: entry?.labels?.en?.trim() || id,
+						es: entry?.labels?.es?.trim() || entry?.labels?.en?.trim() || id,
+					}
+		if (!id) return
+
+		const arr = [...list, id]
 		setList(arr)
 
 		let nextActive = [...active]
-		if (!nextActive.includes(tag)) {
+		if (!nextActive.includes(id)) {
 			if (nextActive.length >= maxTags[tagSystem]) {
 				setMaxTagsError(true)
 			} else {
-				nextActive = [...nextActive, tag]
+				nextActive = [...nextActive, id]
 				setMaxTagsError(false)
 			}
 		}
 		setActive(nextActive)
-		setData(tagSystem, arr, nextActive, agencyID)
+		const nextLabels = {
+			...tagLabels,
+			[id]: labels,
+		}
+		setTagLabels(nextLabels)
+		setData(tagSystem, arr, nextActive, agencyID, nextLabels)
 		setSearch('')
 	}
 
@@ -503,7 +577,7 @@ const TagSystem = ({ tagSystem, setTagSystem, agencyID }) => {
 										}}
 										className="text-light text-sm rounded-lg leading-tight py-2 pl-4 hover:bg-indigo-100 cursor-pointer"
 										key={item}>
-										{item}
+										{formatTagDisplay(item)}
 										{isRequiredTag(item, requiredTags) ? ' *' : ''}
 									</div>
 								)
@@ -589,7 +663,7 @@ const TagSystem = ({ tagSystem, setTagSystem, agencyID }) => {
 											key={item}>
 											<GoDotFill size={25} className="text-green-600" />
 											<div className="pl-2">
-												{item}
+												{formatTagDisplay(item)}
 												{isRequiredTag(item, requiredTags) ? '*' : ''}
 											</div>
 										</div>
@@ -627,7 +701,7 @@ const TagSystem = ({ tagSystem, setTagSystem, agencyID }) => {
 											<GoDotFill size={25} className="text-green-600" />
 										)}
 										<div className="pl-2">
-											{item}
+											{formatTagDisplay(item)}
 											{isRequiredTag(item, requiredTags) ? '*' : ''}
 										</div>
 									</div>
@@ -643,7 +717,6 @@ const TagSystem = ({ tagSystem, setTagSystem, agencyID }) => {
 					tagSystems={tagSystems}
 					tagSystem={tagSystem}
 					list={list}
-					setList={setList}
 					setNewTagModal={setNewTagModal}
 					addNewTag={addNewTag}
 				/>
@@ -654,7 +727,7 @@ const TagSystem = ({ tagSystem, setTagSystem, agencyID }) => {
 					selected={selected}
 					list={list}
 					setRenameTagModal={setRenameTagModal}
-					addNewTag={addNewTag}
+					existingLabels={tagLabels[canonicalizeTagId(selected)]}
 				/>
 			)}
 			{newLabelModal && (

--- a/components/modals/reports/AgencyReportModal.jsx
+++ b/components/modals/reports/AgencyReportModal.jsx
@@ -46,7 +46,14 @@ import MediaUploadField from '../../ui/MediaUploadField'
 import { useTranslation } from 'next-i18next'
 import { Typography } from '@material-tailwind/react'
 import { maxActiveTags } from '../../../config/tagSystems'
-import { seedAgencyTagsDoc } from '../../../utils/tag-defaults'
+import {
+	buildTagLabelMap,
+	dedupeTagList,
+	fetchTagDefaults,
+	getTagLabel,
+	isOtherTagName,
+	seedAgencyTagsDoc,
+} from '../../../utils/tag-defaults'
 
 const TOPICS_KEY_PREFIX = 'topics.'
 const SOURCES_KEY_PREFIX = 'sources.'
@@ -77,15 +84,13 @@ function stripSourcesKeyPrefix(sourceId) {
 
 /** True when this topic id is the “Other” row, including legacy `topics.Other` (or repeated prefix) in Firestore. */
 function isOtherTopicValue(value) {
-	if (typeof value !== 'string') return false
-	return stripTopicsKeyPrefix(value) === 'Other'
+	return isOtherTagName(stripTopicsKeyPrefix(value))
 }
 
 /** True when this source id is the “Other” row, including legacy `sources.Other` / `sources.Other/Otro`. */
 function isOtherSourceValue(value) {
-	if (typeof value !== 'string') return false
 	const id = stripSourcesKeyPrefix(value)
-	return id === 'Other' || id === 'Other/Otro'
+	return isOtherTagName(id)
 }
 
 /** Returns true when empty or a valid http(s) URL (protocol optional in input). */
@@ -155,6 +160,7 @@ const AgencyReportModal = ({
 	const [activeSources, setActiveSources] = useState([])
 	const [allSourcesArr, setSources] = useState([])
 	const [selectedSource, setSelectedSource] = useState('')
+	const [tagLabelMap, setTagLabelMap] = useState({})
 	const [activeLabels, setActiveLabels] = useState([])
 	const [agencyLabelColors, setAgencyLabelColors] = useState({})
 	const [selectedLabel, setSelectedLabel] = useState(DEFAULT_REPORT_LABEL)
@@ -165,7 +171,7 @@ const AgencyReportModal = ({
 	const [submitError, setSubmitError] = useState('')
 	const [showCloseConfirm, setShowCloseConfirm] = useState(false)
 
-	const { t } = useTranslation('NewReport')
+	const { t, i18n } = useTranslation('NewReport')
 
 	const clearFieldError = (field) => {
 		setErrors((prev) => {
@@ -722,27 +728,19 @@ const AgencyReportModal = ({
 			// create tags collection if current agency does not have one
 			if (!docRef.exists()) {
 				console.log('Need to create tag collection for agency. ')
-				// One fetch/write — reuse returned payload so UI matches the saved doc
 				const payload = await seedAgencyTagsDoc(selectedAgencyId)
 				if (payload) {
-					setTopics(payload.Topic.list)
-					setList(payload.Topic.list)
-					setActive(payload.Topic.active)
+					setTopics(dedupeTagList(payload.Topic.list))
+					setList(dedupeTagList(payload.Topic.list))
+					setActive(dedupeTagList(payload.Topic.active))
 				}
-				console.log('in if statement')
-
-				// Otherwise, tag collection already exists.
 			} else {
 				const tagsData = docRef.data()['Topic']
-				setTopics(docRef.data()['Topic']['list'])
-				setList(docRef.data()['Topic']['list'] || [])
-				tagsData['active'].sort((a, b) => {
-					if (a === t('Other')) return 1 // Move "Other" to the end
-					if (b === t('Other')) return -1 // Move "Other" to the end
-					return a.localeCompare(b) // Default sorting for other elements
-				})
-				// console.log(tagsData['active'])
-				setActive(tagsData['active'])
+				const list = dedupeTagList(docRef.data()['Topic']['list'] || [])
+				const activeSorted = dedupeTagList(tagsData['active'] || [])
+				setTopics(list)
+				setList(list)
+				setActive(activeSorted)
 			}
 		} catch (error) {
 			console.log(error)
@@ -767,16 +765,12 @@ const AgencyReportModal = ({
 		try {
 			getDoc(doc(db, 'tags', selectedAgencyId)).then((docRef) => {
 				if (docRef.exists()) {
-					// console.log(docRef.data())
 					const tagsData = docRef.data()['Source']
-					setSources(docRef.data()['Source']['active'])
-					setSourceList(docRef.data()['Source']['list'])
-					tagsData['active'].sort((a, b) => {
-						if (a === 'Other') return 1 // Move "Other" to the end
-						if (b === 'Other') return -1 // Move "Other" to the end
-						return a.localeCompare(b) // Default sorting for other elements
-					})
-					setActiveSources(docRef.data()['Source']['active'])
+					const activeSorted = dedupeTagList(tagsData['active'] || [])
+					const list = dedupeTagList(docRef.data()['Source']['list'] || [])
+					setSources(activeSorted)
+					setSourceList(list)
+					setActiveSources(activeSorted)
 				}
 			})
 		} catch (error) {
@@ -1026,14 +1020,16 @@ const AgencyReportModal = ({
 			setActiveLabels([])
 			setAgencyLabelColors({})
 		} else {
+			const defaults = await fetchTagDefaults()
+			setTagLabelMap(buildTagLabelMap(defaults))
 			const docRef = doc(db, 'tags', selectedAgencyId)
 			const docSnap = await getDoc(docRef)
 			if (docSnap.exists()) {
 				const topicData = docSnap.get('Topic')['active']
 				const sourceData = docSnap.get('Source')['active']
 				const labelData = docSnap.get('Labels')?.active || []
-				setTopics(topicData)
-				setSources(sourceData)
+				setTopics(dedupeTagList(topicData || []))
+				setSources(dedupeTagList(sourceData || []))
 				setActiveLabels(labelData)
 				setAgencyLabelColors(docSnap.get('Labels')?.colors || {})
 			} else {
@@ -1048,8 +1044,14 @@ const AgencyReportModal = ({
 	 */
 	const handleNewReportModalClose = requestClose
 
-	const topicOptions = allTopicsArr.map((topic) => ({
-		label: t('topics.' + stripTopicsKeyPrefix(topic), topic),
+	const topicOptions = dedupeTagList(allTopicsArr).map((topic) => ({
+		label: getTagLabel({
+			id: topic,
+			locale: i18n.language,
+			labelMap: tagLabelMap,
+			t,
+			system: 'topics',
+		}),
 		value: topic,
 	}))
 
@@ -1057,16 +1059,25 @@ const AgencyReportModal = ({
 		topicOptions.find((o) => o.value === selectedTopic) ??
 		(selectedTopic
 			? {
-					label: t(
-						'topics.' + stripTopicsKeyPrefix(selectedTopic),
-						selectedTopic,
-					),
+					label: getTagLabel({
+						id: selectedTopic,
+						locale: i18n.language,
+						labelMap: tagLabelMap,
+						t,
+						system: 'topics',
+					}),
 					value: selectedTopic,
 				}
 			: null)
 
-	const sourceOptions = allSourcesArr.map((source) => ({
-		label: t('sources.' + stripSourcesKeyPrefix(source), source),
+	const sourceOptions = dedupeTagList(allSourcesArr).map((source) => ({
+		label: getTagLabel({
+			id: source,
+			locale: i18n.language,
+			labelMap: tagLabelMap,
+			t,
+			system: 'sources',
+		}),
 		value: source,
 	}))
 
@@ -1074,10 +1085,13 @@ const AgencyReportModal = ({
 		sourceOptions.find((o) => o.value === selectedSource) ??
 		(selectedSource
 			? {
-					label: t(
-						'sources.' + stripSourcesKeyPrefix(selectedSource),
-						selectedSource,
-					),
+					label: getTagLabel({
+						id: selectedSource,
+						locale: i18n.language,
+						labelMap: tagLabelMap,
+						t,
+						system: 'sources',
+					}),
 					value: selectedSource,
 				}
 			: null)

--- a/components/modals/reports/AgencyReportModal.jsx
+++ b/components/modals/reports/AgencyReportModal.jsx
@@ -47,12 +47,16 @@ import { useTranslation } from 'next-i18next'
 import { Typography } from '@material-tailwind/react'
 import { maxActiveTags } from '../../../config/tagSystems'
 import {
+	buildMergedAgencyTagLabelMap,
 	buildTagLabelMap,
 	dedupeTagList,
 	fetchTagDefaults,
 	getTagLabel,
 	isOtherTagName,
+	normalizeAgencyLabelMap,
 	seedAgencyTagsDoc,
+	TAG_LABEL_MAX_LENGTH,
+	validateLabeledTag,
 } from '../../../utils/tag-defaults'
 
 const TOPICS_KEY_PREFIX = 'topics.'
@@ -152,10 +156,14 @@ const AgencyReportModal = ({
 	const [selectedTopic, setSelectedTopic] = useState('')
 	const [otherTopic, setOtherTopic] = useState('')
 	const [otherSource, setOtherSource] = useState('')
+	const [otherTopicEs, setOtherTopicEs] = useState('')
+	const [otherSourceEs, setOtherSourceEs] = useState('')
 	const [showOtherTopic, setShowOtherTopic] = useState(false)
 	const [showOtherSource, setShowOtherSource] = useState(false)
 	const [list, setList] = useState([])
 	const [sourceList, setSourceList] = useState([])
+	const [topicLabels, setTopicLabels] = useState({})
+	const [sourceLabels, setSourceLabels] = useState({})
 	const [active, setActive] = useState([])
 	const [activeSources, setActiveSources] = useState([])
 	const [allSourcesArr, setSources] = useState([])
@@ -193,6 +201,18 @@ const AgencyReportModal = ({
 			return otherSource.trim()
 		}
 		return (selectedSource || '').trim()
+	}
+
+	const topicNeedsCatalogEs = () => {
+		const id = resolveTopicValue()
+		if (!isOtherTopicValue(selectedTopic) || !id) return false
+		return !list.some((t) => t.toLowerCase() === id.toLowerCase())
+	}
+
+	const sourceNeedsCatalogEs = () => {
+		const id = resolveSourceValue()
+		if (!isOtherSourceValue(selectedSource) || !id) return false
+		return !sourceList.some((t) => t.toLowerCase() === id.toLowerCase())
 	}
 	const isFormDirty = () =>
 		Boolean(title.trim()) ||
@@ -250,10 +270,26 @@ const AgencyReportModal = ({
 
 		if (!resolveTopicValue()) {
 			allErrors.topic = t('specify_topic')
+		} else if (topicNeedsCatalogEs()) {
+			const check = validateLabeledTag({
+				id: resolveTopicValue(),
+				labels: { en: resolveTopicValue(), es: otherTopicEs.trim() },
+			})
+			if (!check.ok) {
+				allErrors.topic = check.error || t('specify_topic')
+			}
 		}
 
 		if (!resolveSourceValue()) {
 			allErrors.source = t('source')
+		} else if (sourceNeedsCatalogEs()) {
+			const check = validateLabeledTag({
+				id: resolveSourceValue(),
+				labels: { en: resolveSourceValue(), es: otherSourceEs.trim() },
+			})
+			if (!check.ok) {
+				allErrors.source = check.error || t('source')
+			}
 		}
 
 		if (selectedLabel === OTHER_LABEL) {
@@ -640,6 +676,8 @@ const AgencyReportModal = ({
 			setShowOtherTopic(true)
 		} else {
 			setShowOtherTopic(false)
+			setOtherTopic('')
+			setOtherTopicEs('')
 		}
 		setReportState(5)
 		clearFieldError('topic')
@@ -663,6 +701,8 @@ const AgencyReportModal = ({
 			setShowOtherSource(true)
 		} else {
 			setShowOtherSource(false)
+			setOtherSource('')
+			setOtherSourceEs('')
 		}
 		setReportState(6)
 		clearFieldError('source')
@@ -680,8 +720,12 @@ const AgencyReportModal = ({
 	const addNewTag = (tag, source, agencyId) => {
 		if (!agencyId) return
 
-		const topicArr = list.includes(tag) ? [...list] : [...list, tag]
-		const sourceArr = sourceList.includes(source)
+		const listHas = (arr, id) =>
+			Boolean(id) &&
+			arr.some((t) => String(t).toLowerCase() === String(id).toLowerCase())
+
+		const topicArr = listHas(list, tag) ? [...list] : [...list, tag]
+		const sourceArr = listHas(sourceList, source)
 			? [...sourceList]
 			: [...sourceList, source]
 
@@ -690,21 +734,48 @@ const AgencyReportModal = ({
 
 		const activateTopic =
 			Boolean(tag) &&
-			!nextActive.includes(tag) &&
+			!listHas(nextActive, tag) &&
 			nextActive.length < MAX_ACTIVE_TOPICS
 		const activateSource =
 			Boolean(source) &&
-			!nextActiveSources.includes(source) &&
+			!listHas(nextActiveSources, source) &&
 			nextActiveSources.length < MAX_ACTIVE_SOURCES
 
 		if (activateTopic) nextActive = [...nextActive, tag]
 		if (activateSource) nextActiveSources = [...nextActiveSources, source]
 
+		const nextTopicLabels = { ...topicLabels }
+		const nextSourceLabels = { ...sourceLabels }
+		const isNewTopic = Boolean(tag) && !listHas(list, tag)
+		const isNewSource = Boolean(source) && !listHas(sourceList, source)
+		if (isNewTopic && !isOtherTagName(tag)) {
+			nextTopicLabels[tag] = {
+				en: tag,
+				es: otherTopicEs.trim() || tag,
+			}
+		}
+		if (isNewSource && !isOtherTagName(source)) {
+			nextSourceLabels[source] = {
+				en: source,
+				es: otherSourceEs.trim() || source,
+			}
+		}
+
 		setList(topicArr)
 		setSourceList(sourceArr)
 		setActive(nextActive)
 		setActiveSources(nextActiveSources)
-		updateTopicTags(tag, source, agencyId, activateTopic, activateSource)
+		setTopicLabels(nextTopicLabels)
+		setSourceLabels(nextSourceLabels)
+		updateTopicTags(
+			tag,
+			source,
+			agencyId,
+			activateTopic,
+			activateSource,
+			isNewTopic ? nextTopicLabels[tag] : null,
+			isNewSource ? nextSourceLabels[source] : null,
+		)
 	}
 
 	/**
@@ -733,6 +804,7 @@ const AgencyReportModal = ({
 					setTopics(dedupeTagList(payload.Topic.list))
 					setList(dedupeTagList(payload.Topic.list))
 					setActive(dedupeTagList(payload.Topic.active))
+					setTopicLabels(normalizeAgencyLabelMap(payload.Topic.labels))
 				}
 			} else {
 				const tagsData = docRef.data()['Topic']
@@ -741,6 +813,7 @@ const AgencyReportModal = ({
 				setTopics(list)
 				setList(list)
 				setActive(activeSorted)
+				setTopicLabels(normalizeAgencyLabelMap(tagsData?.labels))
 			}
 		} catch (error) {
 			console.log(error)
@@ -771,6 +844,7 @@ const AgencyReportModal = ({
 					setSources(activeSorted)
 					setSourceList(list)
 					setActiveSources(activeSorted)
+					setSourceLabels(normalizeAgencyLabelMap(tagsData?.labels))
 				}
 			})
 		} catch (error) {
@@ -795,26 +869,59 @@ const AgencyReportModal = ({
 		agencyId,
 		activateTopic,
 		activateSource,
+		topicLabelEntry = null,
+		sourceLabelEntry = null,
 	) => {
 		try {
 			const docRef = doc(db, 'tags', agencyId)
+			const snap = await getDoc(docRef)
+			const data = snap.exists() ? snap.data() : {}
 			const updates = {}
 
 			if (tag) {
 				updates['Topic.list'] = arrayUnion(tag)
 				if (activateTopic) updates['Topic.active'] = arrayUnion(tag)
+				if (topicLabelEntry) {
+					updates['Topic.labels'] = {
+						...(data.Topic?.labels || {}),
+						[tag]: topicLabelEntry,
+					}
+				}
 			}
 			if (source) {
 				updates['Source.list'] = arrayUnion(source)
 				if (activateSource) updates['Source.active'] = arrayUnion(source)
+				if (sourceLabelEntry) {
+					updates['Source.labels'] = {
+						...(data.Source?.labels || {}),
+						[source]: sourceLabelEntry,
+					}
+				}
 			}
 
 			if (Object.keys(updates).length === 0) return
 
-			await updateDoc(docRef, updates)
-			console.log('Tags updated successfully')
+			if (snap.exists()) {
+				await updateDoc(docRef, updates)
+			} else {
+				await setDoc(docRef, {
+					Topic: {
+						list: tag ? [tag] : [],
+						active: tag && activateTopic ? [tag] : [],
+						labels: topicLabelEntry && tag ? { [tag]: topicLabelEntry } : {},
+					},
+					Source: {
+						list: source ? [source] : [],
+						active: source && activateSource ? [source] : [],
+						labels:
+							sourceLabelEntry && source
+								? { [source]: sourceLabelEntry }
+								: {},
+					},
+				})
+			}
 		} catch (error) {
-			console.error('Error updating tags:', error.message)
+			console.error('Error updating agency tags:', error)
 		}
 	}
 
@@ -830,7 +937,6 @@ const AgencyReportModal = ({
 	 */
 	const handleOtherTopicChange = (e) => {
 		setOtherTopic(e.target.value)
-		setSelectedTopic(e.target.value)
 		clearFieldError('topic')
 	}
 
@@ -846,7 +952,6 @@ const AgencyReportModal = ({
 	 */
 	const handleOtherSourceChange = (e) => {
 		setOtherSource(e.target.value)
-		setSelectedSource(e.target.value)
 		clearFieldError('source')
 	}
 
@@ -1019,20 +1124,32 @@ const AgencyReportModal = ({
 			setSources([])
 			setActiveLabels([])
 			setAgencyLabelColors({})
+			setTopicLabels({})
+			setSourceLabels({})
 		} else {
 			const defaults = await fetchTagDefaults()
-			setTagLabelMap(buildTagLabelMap(defaults))
 			const docRef = doc(db, 'tags', selectedAgencyId)
 			const docSnap = await getDoc(docRef)
 			if (docSnap.exists()) {
-				const topicData = docSnap.get('Topic')['active']
-				const sourceData = docSnap.get('Source')['active']
-				const labelData = docSnap.get('Labels')?.active || []
+				const data = docSnap.data()
+				const topicData = data.Topic?.active
+				const sourceData = data.Source?.active
+				const labelData = data.Labels?.active || []
 				setTopics(dedupeTagList(topicData || []))
 				setSources(dedupeTagList(sourceData || []))
+				setList(dedupeTagList(data.Topic?.list || []))
+				setSourceList(dedupeTagList(data.Source?.list || []))
+				setActive(dedupeTagList(data.Topic?.active || []))
+				setActiveSources(dedupeTagList(data.Source?.active || []))
+				setTopicLabels(normalizeAgencyLabelMap(data.Topic?.labels))
+				setSourceLabels(normalizeAgencyLabelMap(data.Source?.labels))
 				setActiveLabels(labelData)
-				setAgencyLabelColors(docSnap.get('Labels')?.colors || {})
+				setAgencyLabelColors(data.Labels?.colors || {})
+				setTagLabelMap(buildMergedAgencyTagLabelMap(defaults, data))
 			} else {
+				setTagLabelMap(buildTagLabelMap(defaults))
+				setTopicLabels({})
+				setSourceLabels({})
 				setActiveLabels(DEFAULT_AGENCY_LABELS)
 				setAgencyLabelColors({})
 			}
@@ -1192,14 +1309,29 @@ const AgencyReportModal = ({
 									/>
 									<FieldError message={errors.topic} />
 									{showOtherTopic && (
-										<div className="mt-4">
+										<div className="mt-4 flex flex-col gap-2">
 											<FormInput
 												id="topic-other"
 												type="text"
-												label={t('specify_topic')}
+												label="English id / label (EN)"
 												onChange={handleOtherTopicChange}
 												value={otherTopic}
+												maxLength={TAG_LABEL_MAX_LENGTH}
 											/>
+											{topicNeedsCatalogEs() && (
+												<FormInput
+													id="topic-other-es"
+													type="text"
+													label="Label (ES)"
+													onChange={(e) => {
+														setOtherTopicEs(e.target.value)
+														clearFieldError('topic')
+													}}
+													value={otherTopicEs}
+													maxLength={TAG_LABEL_MAX_LENGTH}
+													required
+												/>
+											)}
 										</div>
 									)}
 								</div>
@@ -1214,14 +1346,29 @@ const AgencyReportModal = ({
 									/>
 									<FieldError message={errors.source} />
 									{showOtherSource && (
-										<div className="mt-4">
+										<div className="mt-4 flex flex-col gap-2">
 											<FormInput
 												id="source-other"
 												type="text"
-												label={t('source')}
+												label="English id / label (EN)"
 												onChange={handleOtherSourceChange}
 												value={otherSource}
+												maxLength={TAG_LABEL_MAX_LENGTH}
 											/>
+											{sourceNeedsCatalogEs() && (
+												<FormInput
+													id="source-other-es"
+													type="text"
+													label="Label (ES)"
+													onChange={(e) => {
+														setOtherSourceEs(e.target.value)
+														clearFieldError('source')
+													}}
+													value={otherSourceEs}
+													maxLength={TAG_LABEL_MAX_LENGTH}
+													required
+												/>
+											)}
 										</div>
 									)}
 								</div>

--- a/components/modals/reports/ReportModal.jsx
+++ b/components/modals/reports/ReportModal.jsx
@@ -47,6 +47,8 @@ import {
 } from '../../../config/labels'
 import LabelSelectMenu from '../../reports/LabelSelectMenu'
 import { formatReportLocation } from '../../../utils/format-location'
+import { useTranslation } from 'next-i18next'
+import { getTagLabel } from '../../../utils/tag-defaults'
 
 /**
  * ReportModal Component
@@ -129,6 +131,7 @@ const ReportModal = ({
 	changeStatus,
 	reportModalId,
 }) => {
+	const { t, i18n } = useTranslation('NewReport')
 	// CSS styles object for consistent styling across the modal
 	const style = {
 		header: "text-lg font-bold text-black tracking-wider mb-4",
@@ -261,7 +264,14 @@ const ReportModal = ({
 											<div className='font-semibold px-2 self-center pr-4'>
 												Tag
 											</div>
-											<div className='text-md font-light'>{report.topic}</div>
+											<div className='text-md font-light'>
+												{getTagLabel({
+													id: report.topic,
+													locale: i18n.language,
+													t,
+													system: 'topics',
+												})}
+											</div>
 										</div>
 										
 										{/* Sources/Media */}
@@ -271,7 +281,12 @@ const ReportModal = ({
 												Sources / Media
 											</div>
 											<div className='text-md font-light'>
-												{report.hearFrom}
+												{getTagLabel({
+													id: report.hearFrom,
+													locale: i18n.language,
+													t,
+													system: 'sources',
+												})}
 											</div>
 										</div>
 										

--- a/components/modals/reports/ReportModal.jsx
+++ b/components/modals/reports/ReportModal.jsx
@@ -22,6 +22,7 @@
  */
 
 import React, { useEffect, useState } from "react"
+import { resolveAgencyIdByName } from '../../../utils/label-tags'
 import { Switch } from "@material-tailwind/react";
 import FormInput from '../../ui/FormInput'
 import FormTextarea from '../../ui/FormTextarea'
@@ -48,7 +49,10 @@ import {
 import LabelSelectMenu from '../../reports/LabelSelectMenu'
 import { formatReportLocation } from '../../../utils/format-location'
 import { useTranslation } from 'next-i18next'
-import { getTagLabel } from '../../../utils/tag-defaults'
+import {
+	fetchMergedTagLabelMapForAgencyId,
+	getTagLabel,
+} from '../../../utils/tag-defaults'
 
 /**
  * ReportModal Component
@@ -154,12 +158,26 @@ const ReportModal = ({
 	// Local state management
 	const [images,setImages] = useState([]) // Image gallery state
 	const [shareReportModal, setShareReportModal] = useState(false) // Share modal visibility
-	
-	// useEffect(() => {
-	// 	console.log(customClaims);
-	// }, [reportModalId])
-	
-	
+	const [tagLabelMap, setTagLabelMap] = useState({})
+
+	useEffect(() => {
+		let cancelled = false
+		const loadLabels = async () => {
+			try {
+				const agencyId = await resolveAgencyIdByName(report?.agency)
+				const map = await fetchMergedTagLabelMapForAgencyId(agencyId)
+				if (!cancelled) setTagLabelMap(map)
+			} catch (err) {
+				console.error('Error loading tag labels for report modal:', err)
+				if (!cancelled) setTagLabelMap({})
+			}
+		}
+		loadLabels()
+		return () => {
+			cancelled = true
+		}
+	}, [report?.agency, reportModalId])
+
 	return (
 		<div
 			className='report-modal-overlay fixed z-[9998] top-0 left-0 w-full h-full bg-black bg-opacity-50 overflow-auto' // {style.overlay}
@@ -268,6 +286,7 @@ const ReportModal = ({
 												{getTagLabel({
 													id: report.topic,
 													locale: i18n.language,
+													labelMap: tagLabelMap,
 													t,
 													system: 'topics',
 												})}
@@ -284,6 +303,7 @@ const ReportModal = ({
 												{getTagLabel({
 													id: report.hearFrom,
 													locale: i18n.language,
+													labelMap: tagLabelMap,
 													t,
 													system: 'sources',
 												})}

--- a/components/modals/tagging/NewTagModal.jsx
+++ b/components/modals/tagging/NewTagModal.jsx
@@ -1,73 +1,129 @@
 import React, { useState } from 'react'
-import { IoClose } from "react-icons/io5"
+import { IoClose } from 'react-icons/io5'
 import FormInput from '../../ui/FormInput'
+import {
+	TAG_ID_MAX_LENGTH,
+	TAG_LABEL_MAX_LENGTH,
+	isOtherTagName,
+	validateLabeledTag,
+} from '../../../utils/tag-defaults'
 
-const NewTagModal = ({ tagSystems, tagSystem, list, setNewTagModal, addNewTag }) => {
-    const lower = []
-    list.forEach(element => {
-        lower.push(element.toLowerCase())
-    })
-    const [tag, setTag] = useState("")
+/**
+ * Modal to add a custom agency Topic/Source tag with EN id + EN/ES labels.
+ *
+ * @param {{
+ *   tagSystems: string[],
+ *   tagSystem: number,
+ *   list: string[],
+ *   setNewTagModal: (open: boolean) => void,
+ *   addNewTag: (entry: { id: string, labels: { en: string, es: string } }) => void,
+ * }} props
+ */
+const NewTagModal = ({
+	tagSystems,
+	tagSystem,
+	list,
+	setNewTagModal,
+	addNewTag,
+}) => {
+	const existing = (list || []).map((el) => el.toLowerCase())
+	const [id, setId] = useState('')
+	const [labelEn, setLabelEn] = useState('')
+	const [labelEs, setLabelEs] = useState('')
+	const [error, setError] = useState('')
 
-    const handleChange = (e) => {
-        setTag(e.target.value)
-    }
+	const handleAddNewTag = (e) => {
+		e.preventDefault()
+		const entry = {
+			id: id.trim(),
+			labels: { en: labelEn.trim(), es: labelEs.trim() },
+		}
+		const check = validateLabeledTag(entry)
+		if (!check.ok) {
+			setError(check.error || 'Invalid tag.')
+			return
+		}
+		if (isOtherTagName(entry.id)) {
+			setError('Other is reserved and cannot be added again.')
+			return
+		}
+		if (existing.includes(entry.id.toLowerCase())) {
+			setError('This tag already exists, please try another id.')
+			return
+		}
+		addNewTag(entry)
+		setNewTagModal(false)
+	}
 
-    const handleAddNewTag = (e) => {
-        e.preventDefault()
-        if (!lower.includes(tag.toLowerCase()) && tag.length != 0 && tag.length <= 20) {
-            addNewTag(tag)
-            setNewTagModal(false)
-        }
-    }
-
-
-    return (
-        <div>
-            <div className="flex z-[9998] justify-center items-center absolute top-0 left-0 w-full h-full bg-black opacity-60">
-            </div>
-            <div onClick={() => setNewTagModal(false)} className="flex justify-center items-center z-[9999] absolute top-0 left-0 w-full h-full">
-                <div className="flex-col justify-center items-center bg-white w-80 h-auto rounded-2xl py-10 px-10"
-                    onClick={(e) => {
-                        e.stopPropagation()
-                    }}>
-                    <div className="flex justify-between w-full mb-5">
-                        <div className="text-md font-bold text-blue-600 tracking-wide">{"Add New " + tagSystems[tagSystem]}</div>
-                        <button onClick={() => setNewTagModal(false)} className="text-gray-800">
-                            <IoClose size={25}/>
-                        </button>
-                    </div>
-                    <form onChange={handleChange} onSubmit={handleAddNewTag}>
-                        <div className="mb-2">
-                            <FormInput
-                                id="newTag"
-                                type="text"
-                                label="New Tag"
-                                value={tag}
-                                required
-                                onChange={handleChange}
-                                />
-                        </div>
-                        {lower.includes(tag.toLowerCase()) && <p className="text-red-500 text-sm font-light">This tag already exists, please try another name</p>}
-                        {tag.length > 20 && <p className="text-red-500 text-sm font-light">You cannot type a tag more than 20 characters long. Please try another name</p>}
-                        <div className="mt-6 flex justify-between">
-                            <button
-                                onClick={() => setNewTagModal(false)}
-                                className="bg-white hover:bg-red-500 hover:text-white text-sm text-red-500 font-bold py-1.5 px-6 rounded-md focus:outline-none focus:shadow-outline"
-                                type='button'>
-                                Cancel
-                            </button>
-                            <button
-                                className="bg-white hover:bg-blue-600 hover:text-white text-sm text-blue-500 font-bold py-1.5 px-6 rounded-md focus:outline-none focus:shadow-outline"
-                                type="submit">
-                                Add
-                            </button>
-                        </div>
-                    </form>
-                </div>
-            </div>
-        </div>
-    )
+	return (
+		<div>
+			<div className="flex z-[9998] justify-center items-center absolute top-0 left-0 w-full h-full bg-black opacity-60" />
+			<div
+				onClick={() => setNewTagModal(false)}
+				className="flex justify-center items-center z-[9999] absolute top-0 left-0 w-full h-full">
+				<div
+					className="flex-col justify-center items-center bg-white w-96 max-w-[95vw] h-auto rounded-2xl py-10 px-10"
+					onClick={(e) => e.stopPropagation()}>
+					<div className="flex justify-between w-full mb-5">
+						<div className="text-md font-bold text-blue-600 tracking-wide">
+							{'Add New ' + tagSystems[tagSystem]}
+						</div>
+						<button
+							onClick={() => setNewTagModal(false)}
+							className="text-gray-800"
+							type="button">
+							<IoClose size={25} />
+						</button>
+					</div>
+					<form onSubmit={handleAddNewTag} className="flex flex-col gap-2">
+						<FormInput
+							id="newTagId"
+							type="text"
+							label="English id (stored)"
+							value={id}
+							required
+							maxLength={TAG_ID_MAX_LENGTH}
+							onChange={(e) => setId(e.target.value)}
+						/>
+						<FormInput
+							id="newTagEn"
+							type="text"
+							label="Label (EN)"
+							value={labelEn}
+							required
+							maxLength={TAG_LABEL_MAX_LENGTH}
+							onChange={(e) => setLabelEn(e.target.value)}
+						/>
+						<FormInput
+							id="newTagEs"
+							type="text"
+							label="Label (ES)"
+							value={labelEs}
+							required
+							maxLength={TAG_LABEL_MAX_LENGTH}
+							onChange={(e) => setLabelEs(e.target.value)}
+						/>
+						{error && (
+							<p className="text-red-500 text-sm font-light">{error}</p>
+						)}
+						<div className="mt-6 flex justify-between">
+							<button
+								onClick={() => setNewTagModal(false)}
+								className="bg-white hover:bg-red-500 hover:text-white text-sm text-red-500 font-bold py-1.5 px-6 rounded-md focus:outline-none focus:shadow-outline"
+								type="button">
+								Cancel
+							</button>
+							<button
+								className="bg-white hover:bg-blue-600 hover:text-white text-sm text-blue-500 font-bold py-1.5 px-6 rounded-md focus:outline-none focus:shadow-outline"
+								type="submit">
+								Add
+							</button>
+						</div>
+					</form>
+				</div>
+			</div>
+		</div>
+	)
 }
 
 export default NewTagModal

--- a/components/modals/tagging/RenameTagModal.jsx
+++ b/components/modals/tagging/RenameTagModal.jsx
@@ -1,89 +1,138 @@
 import React, { useState } from 'react'
-import { IoClose } from "react-icons/io5"
+import { IoClose } from 'react-icons/io5'
 import FormInput from '../../ui/FormInput'
+import {
+	TAG_ID_MAX_LENGTH,
+	TAG_LABEL_MAX_LENGTH,
+	isOtherTagName,
+	validateLabeledTag,
+} from '../../../utils/tag-defaults'
 
-const RenameTagModal = ({ replaceTag, selected, list, setRenameTagModal, addNewTag }) => {
-    const lower = []
-    list.forEach(element => {
-        lower.push(element.toLowerCase())
-    })
-    const [tag, setTag] = useState("")
+/**
+ * Modal to rename/edit a custom agency tag id and EN/ES labels.
+ *
+ * @param {{
+ *   replaceTag: (entry: { id: string, labels: { en: string, es: string } }) => void,
+ *   selected: string,
+ *   list: string[],
+ *   setRenameTagModal: (open: boolean) => void,
+ *   existingLabels?: { en?: string, es?: string },
+ * }} props
+ */
+const RenameTagModal = ({
+	replaceTag,
+	selected,
+	list,
+	setRenameTagModal,
+	existingLabels,
+}) => {
+	const existing = (list || [])
+		.filter((el) => el.toLowerCase() !== String(selected || '').toLowerCase())
+		.map((el) => el.toLowerCase())
 
-    const handleChange = (e) => {
-        try {
-            setTag(e.target.value)
-        } catch (error) {
-            console.error("Error in handleChange:", error)
-        }
-    }
+	const [id, setId] = useState(selected || '')
+	const [labelEn, setLabelEn] = useState(existingLabels?.en || selected || '')
+	const [labelEs, setLabelEs] = useState(existingLabels?.es || '')
+	const [error, setError] = useState('')
 
-    const handleAddNewTag = (e) => {
-        e.preventDefault()
-        try {
-            if (tag.length != 0 && tag.length <= 20) {
-                addNewTag(tag)
-                setRenameTagModal(false)
-            }
-        } catch (error) {
-            console.error("Error in handleAddNewTag:", error)
-        }
-    }
+	const commit = (e) => {
+		e.preventDefault()
+		const entry = {
+			id: id.trim(),
+			labels: { en: labelEn.trim(), es: labelEs.trim() },
+		}
+		const check = validateLabeledTag(entry)
+		if (!check.ok) {
+			setError(check.error || 'Invalid tag.')
+			return
+		}
+		if (isOtherTagName(entry.id)) {
+			setError('Cannot rename a tag to Other.')
+			return
+		}
+		if (existing.includes(entry.id.toLowerCase())) {
+			setError('This tag id already exists.')
+			return
+		}
+		if (entry.id !== selected) {
+			const ok = window.confirm(
+				`Change id from "${selected}" to "${entry.id}"?\n\nExisting reports still using the old id will not be remapped automatically.`,
+			)
+			if (!ok) return
+		}
+		replaceTag(entry)
+		setRenameTagModal(false)
+	}
 
-    const handleReplaceTag = (e) => {
-        e.preventDefault()
-        try {
-            if (!lower.includes(tag.toLowerCase()) && tag.length != 0 && tag.length <= 25) {
-                replaceTag(tag)
-                setRenameTagModal(false)
-            }
-        } catch (error) {
-            console.error("Error in handleReplaceTag:", error)
-        }
-    }
-
-    return (
-        <div>
-            <div className="flex justify-center items-center z-[9998] absolute top-0 left-0 w-full h-full bg-black opacity-60">
-            </div>
-            <div onClick={() => setRenameTagModal(false)} className="flex justify-center items-center z-[9999] absolute top-0 left-0 w-full h-full">
-                <div onClick={(e) => { e.stopPropagation() }} className="flex-col justify-center items-center bg-white w-80 h-auto rounded-2xl py-10 px-10">
-                    <div className="flex justify-between w-full mb-5">
-                        <div className="text-md font-bold text-blue-600 tracking-wide">Rename</div>
-                        <button onClick={() => setRenameTagModal(false)} className="text-gray-800">
-                            <IoClose size={25}/>
-                        </button>
-                    </div>
-                    <form onChange={handleChange} onSubmit={handleAddNewTag}>
-                        <div className="mb-2">
-                            <FormInput
-                                id="newTag"
-                                type="text"
-                                label={selected}
-                                value={tag}
-                                required
-                                onChange={handleChange}
-                                />
-                        </div>
-                        {lower.includes(tag.toLowerCase()) && <p className="text-red-500 text-sm font-light">This tag already exists, do you want to replace?</p>}
-                        {tag.length > 25 && <p className="text-red-500 text-sm font-light">You cannot type a tag more than 18 characters long. Please try another name</p>}
-                        <div className="mt-6 flex justify-between">
-                            <button
-                                onClick={handleReplaceTag}
-                                className="bg-white hover:bg-gray-500 hover:text-white text-sm text-gray-500 font-bold py-1.5 px-6 rounded-md focus:outline-none focus:shadow-outline"
-                                 type='button'>
-                                Replace
-                            </button>
-                            <button
-                                className="bg-white hover:bg-blue-600 hover:text-white text-sm text-blue-500 font-bold py-1.5 px-6 rounded-md focus:outline-none focus:shadow-outline"
-                                type="submit">
-                                Keep Both
-                            </button>
-                        </div>
-                    </form>
-                </div>
-            </div>
-        </div>
-    )
+	return (
+		<div>
+			<div className="flex justify-center items-center z-[9998] absolute top-0 left-0 w-full h-full bg-black opacity-60" />
+			<div
+				onClick={() => setRenameTagModal(false)}
+				className="flex justify-center items-center z-[9999] absolute top-0 left-0 w-full h-full">
+				<div
+					onClick={(e) => e.stopPropagation()}
+					className="flex-col justify-center items-center bg-white w-96 max-w-[95vw] h-auto rounded-2xl py-10 px-10">
+					<div className="flex justify-between w-full mb-5">
+						<div className="text-md font-bold text-blue-600 tracking-wide">
+							Edit tag
+						</div>
+						<button
+							onClick={() => setRenameTagModal(false)}
+							className="text-gray-800"
+							type="button">
+							<IoClose size={25} />
+						</button>
+					</div>
+					<form onSubmit={commit} className="flex flex-col gap-2">
+						<FormInput
+							id="renameTagId"
+							type="text"
+							label="English id (stored)"
+							value={id}
+							required
+							maxLength={TAG_ID_MAX_LENGTH}
+							onChange={(e) => setId(e.target.value)}
+						/>
+						<FormInput
+							id="renameTagEn"
+							type="text"
+							label="Label (EN)"
+							value={labelEn}
+							required
+							maxLength={TAG_LABEL_MAX_LENGTH}
+							onChange={(e) => setLabelEn(e.target.value)}
+						/>
+						<FormInput
+							id="renameTagEs"
+							type="text"
+							label="Label (ES)"
+							value={labelEs}
+							required
+							maxLength={TAG_LABEL_MAX_LENGTH}
+							onChange={(e) => setLabelEs(e.target.value)}
+						/>
+						{error && (
+							<p className="text-red-500 text-sm font-light">{error}</p>
+						)}
+						<div className="mt-6 flex justify-between">
+							<button
+								onClick={() => setRenameTagModal(false)}
+								className="bg-white hover:bg-gray-500 hover:text-white text-sm text-gray-500 font-bold py-1.5 px-6 rounded-md focus:outline-none focus:shadow-outline"
+								type="button">
+								Cancel
+							</button>
+							<button
+								className="bg-white hover:bg-blue-600 hover:text-white text-sm text-blue-500 font-bold py-1.5 px-6 rounded-md focus:outline-none focus:shadow-outline"
+								type="submit">
+								Save
+							</button>
+						</div>
+					</form>
+				</div>
+			</div>
+		</div>
+	)
 }
 
 export default RenameTagModal

--- a/components/partials/report/SourceSelector.jsx
+++ b/components/partials/report/SourceSelector.jsx
@@ -1,42 +1,66 @@
-import React from 'react';
-import { List, ListItem, Typography } from '@material-tailwind/react';
-import FormInput from '../../ui/FormInput';
-import { IoIosInformationCircle } from "react-icons/io";
-import { useTranslation } from 'next-i18next'; // Import the useTranslation hook
+import React, { useMemo } from 'react'
+import { ListItem, Typography } from '@material-tailwind/react'
+import FormInput from '../../ui/FormInput'
+import { IoIosInformationCircle } from 'react-icons/io'
+import { useTranslation } from 'next-i18next'
+import {
+	dedupeTagList,
+	getTagLabel,
+	isOtherTagName,
+} from '../../../utils/tag-defaults'
 
-const SourceSelector = ({ sources, selectedSource, handleSourceChange, showOtherSource, handleOtherSourceChange, otherSource }) => {
-    const { t } = useTranslation('NewReport'); // Use the useTranslation hook
-    return (
-        <>
-            {sources.map((source, i) => (
-                <ListItem
-                    id='source'
-                    key={i}
-                    selected={source === selectedSource}
-                    value={source}
-                    onClick={() => handleSourceChange(source)}>
-                    {t(`sources.${source}`)} {/* Translate each source name */}
-                </ListItem>
-            ))}
-            {showOtherSource && (
-                <div className='w-full'>
-                    <FormInput
-                        type='text'
-                        label={t("custom_source")}
-                        value={otherSource}
-                        onChange={handleOtherSourceChange}
-                    />
-                    <Typography
-                        variant='small'
-                        color='gray'
-                        className='mt-2 flex items-start gap-1 font-normal'>
-                        <IoIosInformationCircle size="15" className='mt-1' />
-                        {t("source")} {/* Updated translation key for clarity */}
-                    </Typography>
-                </div>
-            )}
-        </>
-    );
+const SourceSelector = ({
+	sources,
+	selectedSource,
+	handleSourceChange,
+	showOtherSource,
+	handleOtherSourceChange,
+	otherSource,
+	labelMap,
+}) => {
+	const { t, i18n } = useTranslation('NewReport')
+	const list = useMemo(() => dedupeTagList(sources || []), [sources])
+
+	return (
+		<>
+			{list.map((source) => (
+				<ListItem
+					id="source"
+					key={source}
+					selected={
+						source === selectedSource ||
+						(isOtherTagName(selectedSource) && isOtherTagName(source))
+					}
+					value={source}
+					onClick={() => handleSourceChange(source)}>
+					{getTagLabel({
+						id: source,
+						locale: i18n.language,
+						labelMap,
+						t,
+						system: 'sources',
+					})}
+				</ListItem>
+			))}
+			{showOtherSource && (
+				<div className="w-full">
+					<FormInput
+						type="text"
+						label={t('custom_source')}
+						value={otherSource}
+						onChange={handleOtherSourceChange}
+					/>
+					<Typography
+						variant="small"
+						color="gray"
+						className="mt-2 flex items-start gap-1 font-normal">
+						<IoIosInformationCircle size="15" className="mt-1" />
+						{t('source')}
+					</Typography>
+				</div>
+			)}
+		</>
+	)
 }
 
-export default SourceSelector;
+export default SourceSelector

--- a/components/partials/report/TopicSelector.jsx
+++ b/components/partials/report/TopicSelector.jsx
@@ -1,43 +1,66 @@
-import React from 'react';
-import { List, ListItem, Typography } from '@material-tailwind/react';
-import FormInput from '../../ui/FormInput';
-import { IoIosInformationCircle } from "react-icons/io";
-import { useTranslation } from 'next-i18next'; // Import the useTranslation hook
+import React, { useMemo } from 'react'
+import { ListItem, Typography } from '@material-tailwind/react'
+import FormInput from '../../ui/FormInput'
+import { IoIosInformationCircle } from 'react-icons/io'
+import { useTranslation } from 'next-i18next'
+import {
+	dedupeTagList,
+	getTagLabel,
+	isOtherTagName,
+} from '../../../utils/tag-defaults'
 
-const TopicSelector = ({ topics, selectedTopic, handleTopicChange, showOtherTopic, handleOtherTopicChange, otherTopic }) => {
-  const { t } = useTranslation('NewReport'); // Use the useTranslation hook
+const TopicSelector = ({
+	topics,
+	selectedTopic,
+	handleTopicChange,
+	showOtherTopic,
+	handleOtherTopicChange,
+	otherTopic,
+	labelMap,
+}) => {
+	const { t, i18n } = useTranslation('NewReport')
+	const list = useMemo(() => dedupeTagList(topics || []), [topics])
 
-  return (
-    <>
-      {topics.map((topic, index) => (
-        <ListItem
-          id='topic'
-          key={index}
-          selected={topic === selectedTopic}
-          value={topic}
-          onClick={() => handleTopicChange(topic)}>
-          {t(`topics.${topic}`, topic)} {/* Translate topic names */}
-        </ListItem>
-      ))}
-      {showOtherTopic && (
-        <div className='w-full'>
-          <FormInput
-            type='text'
-            label={t("custom_topic")}
-            value={otherTopic}
-            onChange={handleOtherTopicChange}
-          />
-          <Typography
-            variant='small'
-            color='gray'
-            className='mt-2 flex items-start gap-1 font-normal'>
-            <IoIosInformationCircle size="15" className='mt-1' />
-            {t("specify_topic")}
-          </Typography>
-        </div>
-      )}
-    </>
-  );
+	return (
+		<>
+			{list.map((topic) => (
+				<ListItem
+					id="topic"
+					key={topic}
+					selected={
+						topic === selectedTopic ||
+						(isOtherTagName(selectedTopic) && isOtherTagName(topic))
+					}
+					value={topic}
+					onClick={() => handleTopicChange(topic)}>
+					{getTagLabel({
+						id: topic,
+						locale: i18n.language,
+						labelMap,
+						t,
+						system: 'topics',
+					})}
+				</ListItem>
+			))}
+			{showOtherTopic && (
+				<div className="w-full">
+					<FormInput
+						type="text"
+						label={t('custom_topic')}
+						value={otherTopic}
+						onChange={handleOtherTopicChange}
+					/>
+					<Typography
+						variant="small"
+						color="gray"
+						className="mt-2 flex items-start gap-1 font-normal">
+						<IoIosInformationCircle size="15" className="mt-1" />
+						{t('specify_topic')}
+					</Typography>
+				</div>
+			)}
+		</>
+	)
 }
 
-export default TopicSelector;
+export default TopicSelector

--- a/components/reports/ReportSteps/SourceSelectionStep.jsx
+++ b/components/reports/ReportSteps/SourceSelectionStep.jsx
@@ -1,109 +1,116 @@
 /**
  * @fileoverview SourceSelectionStep - Step 4 of the report creation process
- * 
- * This component handles the source selection step where users choose where
- * they heard about the potential misinformation. Supports both predefined
- * sources and custom source creation.
- * 
- * @module components/reports/ReportSteps/SourceSelectionStep
- * @requires react
- * @requires @material-tailwind/react
- * @requires next-i18next
  */
 
-import React from 'react'
+import React, { useMemo } from 'react'
 import { Typography, Card, List, ListItem } from '@material-tailwind/react'
 import FormInput from '../../ui/FormInput'
-import { IoIosInformationCircle } from "react-icons/io"
+import { IoIosInformationCircle } from 'react-icons/io'
 import { useTranslation } from 'next-i18next'
 import globalStyles from '../../../styles/globalStyles'
 import { CUSTOM_OTHER_TAG_MAX_LENGTH } from '../../../config/tagSystems'
+import {
+	dedupeTagList,
+	getTagLabel,
+	isOtherTagName,
+} from '../../../utils/tag-defaults'
 
 /**
- * SourceSelectionStep Component
- * 
- * Renders the source selection step of the report creation process.
- * Displays a list of available sources and allows custom source creation.
- * 
- * @param {Object} props - Component props
- * @param {Array<string>} props.sources - List of available sources
- * @param {string} props.selectedSource - Currently selected source
- * @param {Function} props.handleSourceChange - Function to handle source selection
- * @param {boolean} props.showOtherSource - Whether to show custom source input
- * @param {string} props.otherSource - Custom source value
- * @param {Function} props.handleOtherSourceChange - Function to handle custom source input
- * @param {Object} props.errors - Form validation errors
- * @param {Function} props.onNext - Function to proceed to next step
- * @returns {JSX.Element} The source selection step component
+ * @param {Object} props
+ * @param {string[]} props.sources
+ * @param {string} props.selectedSource
+ * @param {Function} props.handleSourceChange
+ * @param {boolean} props.showOtherSource
+ * @param {string} props.otherSource
+ * @param {Function} props.handleOtherSourceChange
+ * @param {Object} props.errors
+ * @param {Function} props.onNext
+ * @param {Record<string, { en: string, es: string }>|undefined} props.labelMap
  */
 const SourceSelectionStep = ({
-  sources,
-  selectedSource,
-  handleSourceChange,
-  showOtherSource,
-  otherSource,
-  handleOtherSourceChange,
-  errors,
-  onNext
+	sources,
+	selectedSource,
+	handleSourceChange,
+	showOtherSource,
+	otherSource,
+	handleOtherSourceChange,
+	errors,
+	onNext,
+	labelMap,
 }) => {
-  const { t } = useTranslation('NewReport')
-  
-  // Default sources for translation
-  const defaultSources = ["Newspaper", "Other", "Social", "Website"]
+	const { t, i18n } = useTranslation('NewReport')
+	const locale = i18n.language || 'en'
 
-  return (
-    <div className={globalStyles.form.viewWrapper}>
-      <Typography variant='h5'>{t("where")}</Typography>
-      <Card>
-        <List>
-          {[
-            ...sources.filter((source) => source !== "Other"),
-            ...sources.filter((source) => source === "Other"),
-          ].map((source, i = self.crypto.randomUUID()) => (
-            <ListItem
-              id='source'
-              key={i}
-              selected={source === selectedSource}
-              value={t(source)}
-              onClick={() => handleSourceChange(source)}>
-              {defaultSources.includes(source) ? t("sources." + source) : source}
-            </ListItem>
-          ))}
-        </List>
-      </Card>
-      {errors.source && selectedSource === "" && (
-        <span className='text-red-500'>{errors.source}</span>
-      )}
-      {showOtherSource && (
-        <div className='w-full'>
-          <FormInput
-            label={t("custom_source")}
-            value={otherSource}
-            onChange={handleOtherSourceChange}
-            maxLength={CUSTOM_OTHER_TAG_MAX_LENGTH}
-          />
-          <Typography
-            variant='small'
-            color='gray'
-            className={globalStyles.mdInput.hint}>
-            <IoIosInformationCircle />
-            {t("specify_source", { max: CUSTOM_OTHER_TAG_MAX_LENGTH })}
-          </Typography>
-        </div>
-      )}
-      {selectedSource !== "" && (
-        <div className='absolute bottom-4 right-4 sm:right-6'>
-          <button
-            onClick={onNext}
-            className="bg-blue-600 hover:bg-blue-700 text-white rounded-full p-2">
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
-            </svg>
-          </button>
-        </div>
-      )}
-    </div>
-  )
+	const sourceList = useMemo(() => dedupeTagList(sources || []), [sources])
+
+	return (
+		<div className={globalStyles.form.viewWrapper}>
+			<Typography variant="h5">{t('where')}</Typography>
+			<Card>
+				<List>
+					{sourceList.map((source) => (
+						<ListItem
+							id="source"
+							key={source}
+							selected={
+								source === selectedSource ||
+								(isOtherTagName(selectedSource) && isOtherTagName(source))
+							}
+							value={source}
+							onClick={() => handleSourceChange(source)}>
+							{getTagLabel({
+								id: source,
+								locale,
+								labelMap,
+								t,
+								system: 'sources',
+							})}
+						</ListItem>
+					))}
+				</List>
+			</Card>
+			{errors.source && selectedSource === '' && (
+				<span className="text-red-500">{errors.source}</span>
+			)}
+			{showOtherSource && (
+				<div className="w-full">
+					<FormInput
+						label={t('custom_source')}
+						value={otherSource}
+						onChange={handleOtherSourceChange}
+						maxLength={CUSTOM_OTHER_TAG_MAX_LENGTH}
+					/>
+					<Typography
+						variant="small"
+						color="gray"
+						className={globalStyles.mdInput.hint}>
+						<IoIosInformationCircle />
+						{t('specify_source', { max: CUSTOM_OTHER_TAG_MAX_LENGTH })}
+					</Typography>
+				</div>
+			)}
+			{selectedSource !== '' && (
+				<div className="absolute bottom-4 right-4 sm:right-6">
+					<button
+						onClick={onNext}
+						className="bg-blue-600 hover:bg-blue-700 text-white rounded-full p-2">
+						<svg
+							className="w-6 h-6"
+							fill="none"
+							stroke="currentColor"
+							viewBox="0 0 24 24">
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth={2}
+								d="M13 7l5 5m0 0l-5 5m5-5H6"
+							/>
+						</svg>
+					</button>
+				</div>
+			)}
+		</div>
+	)
 }
 
 export default SourceSelectionStep

--- a/components/reports/ReportSteps/TopicSelectionStep.jsx
+++ b/components/reports/ReportSteps/TopicSelectionStep.jsx
@@ -1,110 +1,116 @@
 /**
  * @fileoverview TopicSelectionStep - Step 3 of the report creation process
- * 
- * This component handles the topic selection step where users choose what
- * topic their report relates to. Supports both predefined topics and custom
- * topic creation.
- * 
- * @module components/reports/ReportSteps/TopicSelectionStep
- * @requires react
- * @requires @material-tailwind/react
- * @requires next-i18next
  */
 
-import React from 'react'
+import React, { useMemo } from 'react'
 import { Typography, Card, List, ListItem } from '@material-tailwind/react'
 import FormInput from '../../ui/FormInput'
-import { IoIosInformationCircle } from "react-icons/io"
+import { IoIosInformationCircle } from 'react-icons/io'
 import { useTranslation } from 'next-i18next'
 import globalStyles from '../../../styles/globalStyles'
 import { CUSTOM_OTHER_TAG_MAX_LENGTH } from '../../../config/tagSystems'
+import {
+	dedupeTagList,
+	getTagLabel,
+	isOtherTagName,
+} from '../../../utils/tag-defaults'
 
 /**
- * TopicSelectionStep Component
- * 
- * Renders the topic selection step of the report creation process.
- * Displays a list of available topics and allows custom topic creation.
- * 
- * @param {Object} props - Component props
- * @param {Array<string>} props.allTopicsArr - List of all available topics
- * @param {string} props.selectedTopic - Currently selected topic
- * @param {Function} props.handleTopicChange - Function to handle topic selection
- * @param {boolean} props.showOtherTopic - Whether to show custom topic input
- * @param {string} props.otherTopic - Custom topic value
- * @param {Function} props.handleOtherTopicChange - Function to handle custom topic input
- * @param {Object} props.errors - Form validation errors
- * @param {Function} props.onNext - Function to proceed to next step
- * @returns {JSX.Element} The topic selection step component
+ * @param {Object} props
+ * @param {string[]} props.allTopicsArr
+ * @param {string} props.selectedTopic
+ * @param {Function} props.handleTopicChange
+ * @param {boolean} props.showOtherTopic
+ * @param {string} props.otherTopic
+ * @param {Function} props.handleOtherTopicChange
+ * @param {Object} props.errors
+ * @param {Function} props.onNext
+ * @param {Record<string, { en: string, es: string }>|undefined} props.labelMap
  */
 const TopicSelectionStep = ({
-  allTopicsArr,
-  selectedTopic,
-  handleTopicChange,
-  showOtherTopic,
-  otherTopic,
-  handleOtherTopicChange,
-  errors,
-  onNext
+	allTopicsArr,
+	selectedTopic,
+	handleTopicChange,
+	showOtherTopic,
+	otherTopic,
+	handleOtherTopicChange,
+	errors,
+	onNext,
+	labelMap,
 }) => {
-  const { t } = useTranslation('NewReport')
-  
-  // Default topics for translation
-  const defaultTopics = ["Health", "Other", "Politics", "Weather"]
+	const { t, i18n } = useTranslation('NewReport')
+	const locale = i18n.language || 'en'
 
-  return (
-    <div className={globalStyles.form.viewWrapper}>
-      <Typography variant='h5'>{t("about")}</Typography>
-      <Card>
-        <List>
-          {[
-            ...allTopicsArr.filter((topic) => topic !== "Other"),
-            ...allTopicsArr.filter((topic) => topic === "Other"),
-          ].map((topic, i = self.crypto.randomUUID()) => (
-            <ListItem
-              id='topic'
-              key={i}
-              selected={topic === selectedTopic}
-              value={topic}
-              onClick={() => handleTopicChange(topic)}>
-              {defaultTopics.includes(topic) ? t("topics." + topic) : topic}
-            </ListItem>
-          ))}
-        </List>
-      </Card>
-      {errors.topic && selectedTopic === "" && (
-        <span className='text-red-500'>{errors.topic}</span>
-      )}
-      {showOtherTopic && (
-        <div className='w-full'>
-          <FormInput
-            label={t("custom_topic")}
-            value={otherTopic}
-            onChange={handleOtherTopicChange}
-            maxLength={CUSTOM_OTHER_TAG_MAX_LENGTH}
-          />
-          <Typography
-            variant='small'
-            color='gray'
-            className={globalStyles.mdInput.hint}>
-            <IoIosInformationCircle />
-            {t("specify_topic", { max: CUSTOM_OTHER_TAG_MAX_LENGTH })}
-          </Typography>
-        </div>
-      )}
-      {/* FORWARD ARROW */}
-      {selectedTopic !== "" && (
-        <div className='absolute bottom-4 right-4 sm:right-6'>
-          <button
-            onClick={onNext}
-            className="bg-blue-600 hover:bg-blue-700 text-white rounded-full p-2">
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
-            </svg>
-          </button>
-        </div>
-      )}
-    </div>
-  )
+	const topics = useMemo(() => dedupeTagList(allTopicsArr || []), [allTopicsArr])
+
+	return (
+		<div className={globalStyles.form.viewWrapper}>
+			<Typography variant="h5">{t('about')}</Typography>
+			<Card>
+				<List>
+					{topics.map((topic) => (
+						<ListItem
+							id="topic"
+							key={topic}
+							selected={
+								topic === selectedTopic ||
+								(isOtherTagName(selectedTopic) && isOtherTagName(topic))
+							}
+							value={topic}
+							onClick={() => handleTopicChange(topic)}>
+							{getTagLabel({
+								id: topic,
+								locale,
+								labelMap,
+								t,
+								system: 'topics',
+							})}
+						</ListItem>
+					))}
+				</List>
+			</Card>
+			{errors.topic && selectedTopic === '' && (
+				<span className="text-red-500">{errors.topic}</span>
+			)}
+			{showOtherTopic && (
+				<div className="w-full">
+					<FormInput
+						label={t('custom_topic')}
+						value={otherTopic}
+						onChange={handleOtherTopicChange}
+						maxLength={CUSTOM_OTHER_TAG_MAX_LENGTH}
+					/>
+					<Typography
+						variant="small"
+						color="gray"
+						className={globalStyles.mdInput.hint}>
+						<IoIosInformationCircle />
+						{t('specify_topic', { max: CUSTOM_OTHER_TAG_MAX_LENGTH })}
+					</Typography>
+				</div>
+			)}
+			{selectedTopic !== '' && (
+				<div className="absolute bottom-4 right-4 sm:right-6">
+					<button
+						onClick={onNext}
+						className="bg-blue-600 hover:bg-blue-700 text-white rounded-full p-2">
+						<svg
+							className="w-6 h-6"
+							fill="none"
+							stroke="currentColor"
+							viewBox="0 0 24 24">
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth={2}
+								d="M13 7l5 5m0 0l-5 5m5-5H6"
+							/>
+						</svg>
+					</button>
+				</div>
+			)}
+		</div>
+	)
 }
 
 export default TopicSelectionStep

--- a/components/reports/ReportSystem.jsx
+++ b/components/reports/ReportSystem.jsx
@@ -49,6 +49,7 @@ import {
 	getFallbackTagDefaults,
 	getRequiredIds,
 	buildTagLabelMap,
+	buildMergedAgencyTagLabelMap,
 	isOtherTagName,
 } from "../../utils/tag-defaults"
 import { CUSTOM_OTHER_TAG_MAX_LENGTH } from "../../config/tagSystems"
@@ -409,12 +410,12 @@ const ReportSystem = ({
 			setSelectedAgencyID(agencyId)
 			const tagsSnap = await getDoc(doc(db, "tags", agencyId))
 			if (tagsSnap.exists()) {
-				const topicActive =
-					tagsSnap.data()?.Topic?.active || topicIds
-				const sourceActive =
-					tagsSnap.data()?.Source?.active || sourceIds
+				const data = tagsSnap.data()
+				const topicActive = data?.Topic?.active || topicIds
+				const sourceActive = data?.Source?.active || sourceIds
 				setAllTopicsArr(topicActive)
 				setSources(sourceActive)
+				setTagLabelMap(buildMergedAgencyTagLabelMap(defaults, data))
 			} else {
 				setAllTopicsArr(topicIds)
 				setSources(sourceIds)

--- a/components/reports/ReportSystem.jsx
+++ b/components/reports/ReportSystem.jsx
@@ -47,6 +47,8 @@ import {
 import {
 	fetchTagDefaults,
 	getFallbackTagDefaults,
+	getRequiredIds,
+	buildTagLabelMap,
 	isOtherTagName,
 } from "../../utils/tag-defaults"
 import { CUSTOM_OTHER_TAG_MAX_LENGTH } from "../../config/tagSystems"
@@ -157,6 +159,7 @@ const ReportSystem = ({
 	const [selectedTopic, setSelectedTopic] = useState("")
 	const [sources, setSources] = useState([])
 	const [selectedSource, setSelectedSource] = useState("")
+	const [tagLabelMap, setTagLabelMap] = useState({})
 	
 	// Form validation and UI state
 	const [errors, setErrors] = useState({})
@@ -383,10 +386,13 @@ const ReportSystem = ({
 		const fallback = getFallbackTagDefaults()
 		try {
 			const defaults = await fetchTagDefaults()
+			setTagLabelMap(buildTagLabelMap(defaults))
+			const topicIds = getRequiredIds(defaults, 'Topic')
+			const sourceIds = getRequiredIds(defaults, 'Source')
 			if (!agencyName) {
 				setSelectedAgencyID("")
-				setAllTopicsArr(defaults.Topic.required)
-				setSources(defaults.Source.required)
+				setAllTopicsArr(topicIds)
+				setSources(sourceIds)
 				return
 			}
 
@@ -394,8 +400,8 @@ const ReportSystem = ({
 			const q = query(agencyCollection, where("name", "==", agencyName))
 			const querySnapshot = await getDocs(q)
 			if (querySnapshot.empty) {
-				setAllTopicsArr(defaults.Topic.required)
-				setSources(defaults.Source.required)
+				setAllTopicsArr(topicIds)
+				setSources(sourceIds)
 				return
 			}
 
@@ -404,19 +410,20 @@ const ReportSystem = ({
 			const tagsSnap = await getDoc(doc(db, "tags", agencyId))
 			if (tagsSnap.exists()) {
 				const topicActive =
-					tagsSnap.data()?.Topic?.active || defaults.Topic.required
+					tagsSnap.data()?.Topic?.active || topicIds
 				const sourceActive =
-					tagsSnap.data()?.Source?.active || defaults.Source.required
+					tagsSnap.data()?.Source?.active || sourceIds
 				setAllTopicsArr(topicActive)
 				setSources(sourceActive)
 			} else {
-				setAllTopicsArr(defaults.Topic.required)
-				setSources(defaults.Source.required)
+				setAllTopicsArr(topicIds)
+				setSources(sourceIds)
 			}
 		} catch (error) {
 			console.error("Error loading tags for agency:", error)
-			setAllTopicsArr(fallback.Topic.required)
-			setSources(fallback.Source.required)
+			setTagLabelMap(buildTagLabelMap(fallback))
+			setAllTopicsArr(getRequiredIds(fallback, 'Topic'))
+			setSources(getRequiredIds(fallback, 'Source'))
 		}
 	}
 
@@ -771,6 +778,7 @@ const ReportSystem = ({
 								handleOtherTopicChange={handleOtherTopicChange}
 								errors={errors}
 								onNext={() => setReportSystem(4)}
+								labelMap={tagLabelMap}
 							/>
 						)}
 
@@ -785,6 +793,7 @@ const ReportSystem = ({
 								handleOtherSourceChange={handleOtherSourceChange}
 								errors={errors}
 								onNext={() => setReportSystem(5)}
+								labelMap={tagLabelMap}
 							/>
 						)}
 

--- a/pages/dashboard/reports/[reportId].jsx
+++ b/pages/dashboard/reports/[reportId].jsx
@@ -50,6 +50,8 @@ import FormTextarea from '../../../components/ui/FormTextarea'
 import LabelSelectMenu from '../../../components/reports/LabelSelectMenu'
 import ShareReportModal from '../../../components/partials/modals/ShareReportModal'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useTranslation } from 'next-i18next'
+import { getTagLabel } from '../../../utils/tag-defaults'
 
 /**
  * ReportDetails Page
@@ -61,6 +63,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
  */
 const ReportDetails = () => {
 	const router = useRouter()
+	const { t, i18n } = useTranslation('NewReport')
 	const [info, setInfo] = useState({})
 	const [reporterInfo, setReporterInfo] = useState({})
 	const [postedDate, setPostedDate] = useState("")
@@ -315,12 +318,26 @@ const ReportDetails = () => {
 						<div className="flex flex-row mb-3 items-center">
 							<RiMessage2Fill size={20} />
 							<div className="font-semibold px-2 self-center pr-4">Tag</div>
-              <div className="text-md font-light">{info['topic']}</div>
+              <div className="text-md font-light">
+								{getTagLabel({
+									id: info['topic'],
+									locale: i18n.language,
+									t,
+									system: 'topics',
+								})}
+							</div>
 						</div>
 						<div className="flex flex-row mb-3 items-center">
 							<BiEditAlt size={20} />
               <div className="font-semibold px-2 self-center pr-4">Sources / Media</div>
-              <div className="text-md font-light">{info['hearFrom']}</div>
+              <div className="text-md font-light">
+								{getTagLabel({
+									id: info['hearFrom'],
+									locale: i18n.language,
+									t,
+									system: 'sources',
+								})}
+							</div>
 						</div>
 						<div className="flex flex-row mb-3 items-center">
 							<AiOutlineFieldTime size={20} />

--- a/pages/dashboard/reports/[reportId].jsx
+++ b/pages/dashboard/reports/[reportId].jsx
@@ -51,7 +51,10 @@ import LabelSelectMenu from '../../../components/reports/LabelSelectMenu'
 import ShareReportModal from '../../../components/partials/modals/ShareReportModal'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
-import { getTagLabel } from '../../../utils/tag-defaults'
+import {
+	fetchMergedTagLabelMapForAgencyId,
+	getTagLabel,
+} from '../../../utils/tag-defaults'
 
 /**
  * ReportDetails Page
@@ -76,6 +79,7 @@ const ReportDetails = () => {
 	const [otherLabelDraft, setOtherLabelDraft] = useState('')
 	const [otherLabelError, setOtherLabelError] = useState('')
 	const [shareReportModal, setShareReportModal] = useState(false)
+	const [tagLabelMap, setTagLabelMap] = useState({})
 
 	const { reportId } = router.query
 	const linkStyle = 'font-light mb-1 text-sm underline underline-offset-1'
@@ -105,6 +109,13 @@ const ReportDetails = () => {
 
 		const resolvedAgencyId = await resolveAgencyIdByName(reportData.agency)
 		setModalAgencyId(resolvedAgencyId || '')
+		try {
+			const map = await fetchMergedTagLabelMapForAgencyId(resolvedAgencyId)
+			setTagLabelMap(map)
+		} catch (err) {
+			console.error('Error loading tag labels for report details:', err)
+			setTagLabelMap({})
+		}
 		if (resolvedAgencyId) {
 			const labels = await fetchAgencyActiveLabels(resolvedAgencyId)
 			setModalAgencyLabels(labels)
@@ -322,6 +333,7 @@ const ReportDetails = () => {
 								{getTagLabel({
 									id: info['topic'],
 									locale: i18n.language,
+									labelMap: tagLabelMap,
 									t,
 									system: 'topics',
 								})}
@@ -334,6 +346,7 @@ const ReportDetails = () => {
 								{getTagLabel({
 									id: info['hearFrom'],
 									locale: i18n.language,
+									labelMap: tagLabelMap,
 									t,
 									system: 'sources',
 								})}

--- a/public/locales/en/NewReport.json
+++ b/public/locales/en/NewReport.json
@@ -80,12 +80,22 @@
     "Health": "Health",
     "Weather": "Weather",
     "Other": "Other",
-    "Politics":"Politics"
+    "Politics": "Politics",
+    "Voting": "Voting",
+    "Senate": "Senate",
+    "Gubernatorial": "Gubernatorial",
+    "Mayoral": "Mayoral",
+    "Election (general)": "Election (general)",
+    "News": "News"
   },
   "sources": {
     "Social": "Social",
     "Newspaper": "Newspaper",
     "Website": "Website",
-    "Other": "Other"},
+    "Television": "Television",
+    "Radio": "Radio",
+    "Podcast": "Podcast",
+    "Other": "Other"
+  },
   "thanksText": "We investigate as many reports as possible, although we aren't always able to get to everything. When we're able, we'd love to share the results of our investigation."
 }

--- a/public/locales/es/NewReport.json
+++ b/public/locales/es/NewReport.json
@@ -84,13 +84,22 @@
     "Health": "Salud",
     "Weather": "Clima",
     "Other": "Otro",
-    "Politics":"Política"
+    "Politics": "Política",
+    "Voting": "Votación",
+    "Senate": "Senado",
+    "Gubernatorial": "Gobernatura",
+    "Mayoral": "Alcaldía",
+    "Election (general)": "Elección (general)",
+    "News": "Noticias"
   },
   "sources": {
-  "Social": "Social",
-  "Newspaper": "Periódico",
-  "Website": "Sitio web",
-  "Other": "Otro"
+    "Social": "Social",
+    "Newspaper": "Periódico",
+    "Website": "Sitio web",
+    "Television": "Televisión",
+    "Radio": "Radio",
+    "Podcast": "Podcast",
+    "Other": "Otro"
   },
   "thanksText": "Investigamos tantas denuncias como sea posible, aunque no siempre podemos llegar a todas."
 }

--- a/utils/tag-defaults.js
+++ b/utils/tag-defaults.js
@@ -1,6 +1,6 @@
 /**
  * Global Topic/Source tag defaults for all agencies.
- * Admins edit `tagSystems/defaults`; newsrooms cannot remove required tags.
+ * Admins edit `tagSystems/defaults` with bilingual labels; newsrooms get English ids only.
  */
 
 import {
@@ -19,46 +19,46 @@ import { maxActiveTags } from '../config/tagSystems'
 
 export const TAG_DEFAULTS_DOC_PATH = ['tagSystems', 'defaults']
 
-/** Fallback when Firestore defaults doc is missing. */
+export const TAG_LABEL_MAX_LENGTH = 40
+export const TAG_ID_MAX_LENGTH = 40
+
+/**
+ * @typedef {{ en: string, es: string }} TagLabels
+ * @typedef {{ id: string, labels: TagLabels }} LabeledTag
+ * @typedef {{ Topic: { required: LabeledTag[] }, Source: { required: LabeledTag[] } }} TagDefaults
+ */
+
+/** @type {LabeledTag[]} */
 export const FALLBACK_TOPIC_REQUIRED = [
-	'Voting',
-	'Senate',
-	'Gubernatorial',
-	'Mayoral',
-	'Election (general)',
-	'Other',
+	{ id: 'Voting', labels: { en: 'Voting', es: 'Votación' } },
+	{ id: 'Senate', labels: { en: 'Senate', es: 'Senado' } },
+	{
+		id: 'Gubernatorial',
+		labels: { en: 'Gubernatorial', es: 'Gobernatura' },
+	},
+	{ id: 'Mayoral', labels: { en: 'Mayoral', es: 'Alcaldía' } },
+	{
+		id: 'Election (general)',
+		labels: { en: 'Election (general)', es: 'Elección (general)' },
+	},
+	{ id: 'Other', labels: { en: 'Other', es: 'Otro' } },
 ]
 
-/** Fallback when Firestore defaults doc is missing. */
+/** @type {LabeledTag[]} */
 export const FALLBACK_SOURCE_REQUIRED = [
-	'Newspaper',
-	'Social',
-	'Website',
-	'Television',
-	'Radio',
-	'Podcast',
-	'Other',
+	{ id: 'Newspaper', labels: { en: 'Newspaper', es: 'Periódico' } },
+	{ id: 'Social', labels: { en: 'Social', es: 'Social' } },
+	{ id: 'Website', labels: { en: 'Website', es: 'Sitio web' } },
+	{ id: 'Television', labels: { en: 'Television', es: 'Televisión' } },
+	{ id: 'Radio', labels: { en: 'Radio', es: 'Radio' } },
+	{ id: 'Podcast', labels: { en: 'Podcast', es: 'Podcast' } },
+	{ id: 'Other', labels: { en: 'Other', es: 'Otro' } },
 ]
 
 const MAX_ACTIVE_TOPICS = maxActiveTags[1]
 const MAX_ACTIVE_SOURCES = maxActiveTags[2]
 
-/**
- * Ensures Other is present and last in a required tag list.
- *
- * @param {string[]} tags
- * @returns {string[]}
- */
-export function ensureOtherInRequired(tags) {
-	const cleaned = (tags || [])
-		.map((t) => (typeof t === 'string' ? t.trim() : ''))
-		.filter(Boolean)
-		.filter((t) => {
-			const lower = t.toLowerCase()
-			return lower !== 'other' && lower !== 'other/otro'
-		})
-	return [...cleaned, 'Other']
-}
+const OTHER_LABELED = { id: 'Other', labels: { en: 'Other', es: 'Otro' } }
 
 /**
  * True when this tag is the locked Other slot (including legacy Other/Otro).
@@ -73,21 +73,151 @@ export function isOtherTagName(name) {
 }
 
 /**
- * True when a tag is in the admin-required set (Other aliases match Other).
+ * Maps legacy / prefixed tag strings to a canonical English id.
  *
  * @param {string} name
- * @param {string[]} requiredList
+ * @returns {string}
+ */
+export function canonicalizeTagId(name) {
+	if (!name || typeof name !== 'string') return ''
+	let id = name.trim()
+	while (id.startsWith('topics.')) id = id.slice('topics.'.length)
+	while (id.startsWith('sources.')) id = id.slice('sources.'.length)
+	if (isOtherTagName(id)) return 'Other'
+	return id
+}
+
+/**
+ * Unique id list with a single trailing Other (collapses Other/Otro aliases).
+ *
+ * @param {string[]} tags
+ * @returns {string[]}
+ */
+export function dedupeTagList(tags) {
+	const seen = new Set()
+	const out = []
+	for (const raw of tags || []) {
+		const id = canonicalizeTagId(typeof raw === 'string' ? raw : '')
+		if (!id || id === 'Other') continue
+		const key = id.toLowerCase()
+		if (seen.has(key)) continue
+		seen.add(key)
+		out.push(id)
+	}
+	out.push('Other')
+	return out
+}
+
+/**
+ * Ensures Other is present and last in a string id list (agency arrays).
+ *
+ * @param {string[]} tags
+ * @returns {string[]}
+ */
+export function ensureOtherInRequired(tags) {
+	return dedupeTagList(tags)
+}
+
+/**
+ * @param {unknown} entry
+ * @returns {LabeledTag|null}
+ */
+function coerceLabeledTag(entry) {
+	if (!entry) return null
+	if (typeof entry === 'string') {
+		const id = canonicalizeTagId(entry)
+		if (!id) return null
+		if (id === 'Other') return { ...OTHER_LABELED }
+		return { id, labels: { en: id, es: id } }
+	}
+	if (typeof entry === 'object') {
+		const id = canonicalizeTagId(
+			typeof entry.id === 'string' ? entry.id : '',
+		)
+		if (!id) return null
+		const en =
+			typeof entry.labels?.en === 'string'
+				? entry.labels.en.trim()
+				: typeof entry.en === 'string'
+					? entry.en.trim()
+					: id
+		const es =
+			typeof entry.labels?.es === 'string'
+				? entry.labels.es.trim()
+				: typeof entry.es === 'string'
+					? entry.es.trim()
+					: en || id
+		if (id === 'Other') {
+			return {
+				id: 'Other',
+				labels: {
+					en: en || 'Other',
+					es: es || 'Otro',
+				},
+			}
+		}
+		return { id, labels: { en: en || id, es: es || en || id } }
+	}
+	return null
+}
+
+/**
+ * Ensures Other is present and last among labeled required tags.
+ *
+ * @param {unknown[]} tags
+ * @returns {LabeledTag[]}
+ */
+export function ensureOtherInLabeledRequired(tags) {
+	const cleaned = []
+	const seen = new Set()
+	for (const raw of tags || []) {
+		const entry = coerceLabeledTag(raw)
+		if (!entry || entry.id === 'Other') continue
+		const key = entry.id.toLowerCase()
+		if (seen.has(key)) continue
+		seen.add(key)
+		cleaned.push(entry)
+	}
+	cleaned.push({
+		id: 'Other',
+		labels: { en: 'Other', es: 'Otro' },
+	})
+	return cleaned
+}
+
+/**
+ * English ids from a defaults system list.
+ *
+ * @param {TagDefaults} defaults
+ * @param {'Topic'|'Source'} system
+ * @returns {string[]}
+ */
+export function getRequiredIds(defaults, system) {
+	const list = defaults?.[system]?.required
+	if (!Array.isArray(list)) return []
+	return ensureOtherInRequired(
+		list.map((entry) =>
+			typeof entry === 'string' ? entry : entry?.id,
+		),
+	)
+}
+
+/**
+ * True when a tag id is in the admin-required set (Other aliases match Other).
+ *
+ * @param {string} name
+ * @param {Array<string|LabeledTag>} requiredList
  * @returns {boolean}
  */
 export function isRequiredTag(name, requiredList) {
 	if (!name || !Array.isArray(requiredList)) return false
-	if (isOtherTagName(name) && requiredList.some(isOtherTagName)) return true
-	return requiredList.includes(name)
+	const ids = requiredList.map((entry) =>
+		typeof entry === 'string' ? entry : entry?.id,
+	)
+	if (isOtherTagName(name) && ids.some(isOtherTagName)) return true
+	const canonical = canonicalizeTagId(name)
+	return ids.some((id) => canonicalizeTagId(id) === canonical)
 }
-
-/**
- * @typedef {{ Topic: { required: string[] }, Source: { required: string[] } }} TagDefaults
- */
 
 /**
  * Returns code fallbacks shaped like the Firestore defaults document.
@@ -96,31 +226,34 @@ export function isRequiredTag(name, requiredList) {
  */
 export function getFallbackTagDefaults() {
 	return {
-		Topic: { required: [...FALLBACK_TOPIC_REQUIRED] },
-		Source: { required: [...FALLBACK_SOURCE_REQUIRED] },
+		Topic: { required: ensureOtherInLabeledRequired(FALLBACK_TOPIC_REQUIRED) },
+		Source: {
+			required: ensureOtherInLabeledRequired(FALLBACK_SOURCE_REQUIRED),
+		},
 	}
 }
 
 /**
- * Normalizes a raw Firestore defaults payload into Topic/Source required lists.
+ * Normalizes a raw Firestore defaults payload into labeled Topic/Source lists.
  *
  * @param {Record<string, unknown>|undefined|null} data
  * @returns {TagDefaults}
  */
 export function normalizeTagDefaults(data) {
 	const fallback = getFallbackTagDefaults()
-	const topicRaw = data?.Topic?.required ?? data?.Topic?.tags ?? fallback.Topic.required
+	const topicRaw =
+		data?.Topic?.required ?? data?.Topic?.tags ?? fallback.Topic.required
 	const sourceRaw =
 		data?.Source?.required ?? data?.Source?.tags ?? fallback.Source.required
 
 	return {
 		Topic: {
-			required: ensureOtherInRequired(
+			required: ensureOtherInLabeledRequired(
 				Array.isArray(topicRaw) ? topicRaw : fallback.Topic.required,
 			),
 		},
 		Source: {
-			required: ensureOtherInRequired(
+			required: ensureOtherInLabeledRequired(
 				Array.isArray(sourceRaw) ? sourceRaw : fallback.Source.required,
 			),
 		},
@@ -144,6 +277,75 @@ export async function fetchTagDefaults() {
 }
 
 /**
+ * Builds a flat id → labels map from defaults (both Topic and Source).
+ *
+ * @param {TagDefaults} defaults
+ * @returns {Record<string, TagLabels>}
+ */
+export function buildTagLabelMap(defaults) {
+	/** @type {Record<string, TagLabels>} */
+	const map = {}
+	for (const system of ['Topic', 'Source']) {
+		for (const entry of defaults?.[system]?.required || []) {
+			const id = canonicalizeTagId(entry?.id)
+			if (!id) continue
+			map[id] = {
+				en: entry.labels?.en || id,
+				es: entry.labels?.es || entry.labels?.en || id,
+			}
+		}
+	}
+	return map
+}
+
+/**
+ * Display label for a tag id.
+ *
+ * @param {{
+ *   id: string,
+ *   locale?: string,
+ *   labelMap?: Record<string, TagLabels>,
+ *   defaults?: TagDefaults,
+ *   t?: (key: string, defaultValue?: string) => string,
+ *   system?: 'topics'|'sources',
+ * }} opts
+ * @returns {string}
+ */
+export function getTagLabel({
+	id,
+	locale = 'en',
+	labelMap,
+	defaults,
+	t,
+	system = 'topics',
+}) {
+	const canonical = canonicalizeTagId(id)
+	if (!canonical) return typeof id === 'string' ? id : ''
+
+	const map = labelMap || (defaults ? buildTagLabelMap(defaults) : null)
+	const labels = map?.[canonical]
+	const lang = String(locale || 'en').toLowerCase().startsWith('es')
+		? 'es'
+		: 'en'
+	if (labels?.[lang]) return labels[lang]
+	if (labels?.en) return labels.en
+
+	if (typeof t === 'function') {
+		const group = t(system, { returnObjects: true })
+		if (
+			group &&
+			typeof group === 'object' &&
+			typeof group[canonical] === 'string' &&
+			group[canonical]
+		) {
+			return group[canonical]
+		}
+	}
+
+	return canonical === 'Other' && lang === 'es' ? 'Otro' : canonical
+}
+
+/**
  * Builds the full agency tags document payload from global defaults + labels.
  *
  * @param {TagDefaults} [defaults]
@@ -151,8 +353,8 @@ export async function fetchTagDefaults() {
  */
 export async function buildAgencyTagsPayload(defaults) {
 	const resolved = defaults || (await fetchTagDefaults())
-	const topics = resolved.Topic.required
-	const sources = resolved.Source.required
+	const topics = getRequiredIds(resolved, 'Topic')
+	const sources = getRequiredIds(resolved, 'Source')
 	return {
 		Topic: { list: [...topics], active: [...topics] },
 		Source: { list: [...sources], active: [...sources] },
@@ -165,8 +367,6 @@ export async function buildAgencyTagsPayload(defaults) {
 
 /**
  * Creates or overwrites an agency tags document seeded from global defaults.
- * Returns the same payload written to Firestore so callers can sync UI state
- * without fetching defaults a second time.
  *
  * @param {string} agencyId
  * @param {TagDefaults} [defaults]
@@ -180,15 +380,43 @@ export async function seedAgencyTagsDoc(agencyId, defaults) {
 }
 
 /**
+ * @param {LabeledTag} entry
+ * @returns {{ ok: boolean, error?: string }}
+ */
+export function validateLabeledTag(entry) {
+	const id = typeof entry?.id === 'string' ? entry.id.trim() : ''
+	const en =
+		typeof entry?.labels?.en === 'string' ? entry.labels.en.trim() : ''
+	const es =
+		typeof entry?.labels?.es === 'string' ? entry.labels.es.trim() : ''
+	if (!id) return { ok: false, error: 'English id is required.' }
+	if (!en) return { ok: false, error: 'English label is required.' }
+	if (!es) return { ok: false, error: 'Spanish label is required.' }
+	if (id.length > TAG_ID_MAX_LENGTH) {
+		return {
+			ok: false,
+			error: `Tag id cannot exceed ${TAG_ID_MAX_LENGTH} characters.`,
+		}
+	}
+	if (en.length > TAG_LABEL_MAX_LENGTH || es.length > TAG_LABEL_MAX_LENGTH) {
+		return {
+			ok: false,
+			error: `Labels cannot exceed ${TAG_LABEL_MAX_LENGTH} characters.`,
+		}
+	}
+	return { ok: true }
+}
+
+/**
  * Validates admin-edited required lists before save.
  *
- * @param {string[]} topicRequired
- * @param {string[]} sourceRequired
+ * @param {LabeledTag[]} topicRequired
+ * @param {LabeledTag[]} sourceRequired
  * @returns {{ ok: boolean, error?: string }}
  */
 export function validateTagDefaults(topicRequired, sourceRequired) {
-	const topics = ensureOtherInRequired(topicRequired)
-	const sources = ensureOtherInRequired(sourceRequired)
+	const topics = ensureOtherInLabeledRequired(topicRequired)
+	const sources = ensureOtherInLabeledRequired(sourceRequired)
 
 	if (topics.length > MAX_ACTIVE_TOPICS) {
 		return {
@@ -202,21 +430,27 @@ export function validateTagDefaults(topicRequired, sourceRequired) {
 			error: `Source defaults cannot exceed ${MAX_ACTIVE_SOURCES} tags (including Other).`,
 		}
 	}
-	if (!topics.some(isOtherTagName) || !sources.some(isOtherTagName)) {
+	if (!topics.some((t) => t.id === 'Other') || !sources.some((t) => t.id === 'Other')) {
 		return { ok: false, error: 'Other must remain in both Topic and Source defaults.' }
 	}
+
+	for (const entry of [...topics, ...sources]) {
+		const check = validateLabeledTag(entry)
+		if (!check.ok) return check
+	}
+
 	return { ok: true }
 }
 
 /**
  * Writes the global defaults document.
  *
- * @param {{ topicRequired: string[], sourceRequired: string[], userId?: string }} params
+ * @param {{ topicRequired: LabeledTag[], sourceRequired: LabeledTag[], userId?: string }} params
  * @returns {Promise<TagDefaults>}
  */
 export async function saveTagDefaults({ topicRequired, sourceRequired, userId }) {
-	const topics = ensureOtherInRequired(topicRequired)
-	const sources = ensureOtherInRequired(sourceRequired)
+	const topics = ensureOtherInLabeledRequired(topicRequired)
+	const sources = ensureOtherInLabeledRequired(sourceRequired)
 	const validation = validateTagDefaults(topics, sources)
 	if (!validation.ok) {
 		throw new Error(validation.error)
@@ -234,16 +468,51 @@ export async function saveTagDefaults({ topicRequired, sourceRequired, userId })
 }
 
 /**
- * Unions required tags into one agency tags doc (additive; leaves retired tags).
+ * Normalizes Topic/Source list+active on one agency tags doc.
+ *
+ * @param {string} agencyId
+ * @returns {Promise<boolean>} true if the document was updated
+ */
+export async function normalizeOtherAliasesForAgency(agencyId) {
+	if (!agencyId || agencyId === 'defaults') return false
+	const docRef = doc(db, 'tags', agencyId)
+	const snap = await getDoc(docRef)
+	if (!snap.exists()) return false
+
+	const data = snap.data() || {}
+	const topicList = dedupeTagList(data.Topic?.list || [])
+	const topicActive = dedupeTagList(data.Topic?.active || [])
+	const sourceList = dedupeTagList(data.Source?.list || [])
+	const sourceActive = dedupeTagList(data.Source?.active || [])
+
+	const same =
+		JSON.stringify(data.Topic?.list || []) === JSON.stringify(topicList) &&
+		JSON.stringify(data.Topic?.active || []) === JSON.stringify(topicActive) &&
+		JSON.stringify(data.Source?.list || []) === JSON.stringify(sourceList) &&
+		JSON.stringify(data.Source?.active || []) === JSON.stringify(sourceActive)
+
+	if (same) return false
+
+	await updateDoc(docRef, {
+		'Topic.list': topicList,
+		'Topic.active': topicActive,
+		'Source.list': sourceList,
+		'Source.active': sourceActive,
+	})
+	return true
+}
+
+/**
+ * Unions required tag ids into one agency tags doc, then normalizes Other aliases.
  *
  * @param {string} agencyId
  * @param {TagDefaults} defaults
  * @returns {Promise<void>}
  */
 export async function propagateRequiredToAgency(agencyId, defaults) {
-	if (!agencyId) return
-	const topics = defaults.Topic.required
-	const sources = defaults.Source.required
+	if (!agencyId || agencyId === 'defaults') return
+	const topics = getRequiredIds(defaults, 'Topic')
+	const sources = getRequiredIds(defaults, 'Source')
 	const docRef = doc(db, 'tags', agencyId)
 	const snap = await getDoc(docRef)
 
@@ -258,6 +527,8 @@ export async function propagateRequiredToAgency(agencyId, defaults) {
 		'Source.list': arrayUnion(...sources),
 		'Source.active': arrayUnion(...sources),
 	})
+
+	await normalizeOtherAliasesForAgency(agencyId)
 }
 
 /**
@@ -270,7 +541,9 @@ export async function propagateRequiredToAllAgencies(defaults) {
 	const tagsSnap = await getDocs(collection(db, 'tags'))
 	const agencySnap = await getDocs(collection(db, 'agency'))
 
-	const tagIds = new Set(tagsSnap.docs.map((d) => d.id))
+	const tagIds = new Set(
+		tagsSnap.docs.map((d) => d.id).filter((id) => id !== 'defaults'),
+	)
 	const agencyIds = agencySnap.docs.map((d) => d.id)
 
 	let updated = 0
@@ -288,9 +561,27 @@ export async function propagateRequiredToAllAgencies(defaults) {
 }
 
 /**
+ * Collapses Other aliases on every agency tags document.
+ *
+ * @returns {Promise<{ updated: number, scanned: number }>}
+ */
+export async function normalizeOtherAliasesForAllAgencies() {
+	const tagsSnap = await getDocs(collection(db, 'tags'))
+	let updated = 0
+	let scanned = 0
+	for (const d of tagsSnap.docs) {
+		if (d.id === 'defaults') continue
+		scanned += 1
+		const changed = await normalizeOtherAliasesForAgency(d.id)
+		if (changed) updated += 1
+	}
+	return { updated, scanned }
+}
+
+/**
  * Saves global defaults and propagates required tags to all agencies.
  *
- * @param {{ topicRequired: string[], sourceRequired: string[], userId?: string }} params
+ * @param {{ topicRequired: LabeledTag[], sourceRequired: LabeledTag[], userId?: string }} params
  * @returns {Promise<{ defaults: TagDefaults, updated: number }>}
  */
 export async function saveAndPropagateTagDefaults(params) {

--- a/utils/tag-defaults.js
+++ b/utils/tag-defaults.js
@@ -299,6 +299,123 @@ export function buildTagLabelMap(defaults) {
 }
 
 /**
+ * Normalizes a Firestore Topic.labels / Source.labels map into id → { en, es }.
+ *
+ * @param {Record<string, unknown>|undefined|null} agencyLabels
+ * @returns {Record<string, TagLabels>}
+ */
+export function normalizeAgencyLabelMap(agencyLabels) {
+	/** @type {Record<string, TagLabels>} */
+	const map = {}
+	if (!agencyLabels || typeof agencyLabels !== 'object') return map
+	for (const [rawId, rawLabels] of Object.entries(agencyLabels)) {
+		const id = canonicalizeTagId(rawId)
+		if (!id || id === 'Other') continue
+		const en =
+			typeof rawLabels?.en === 'string'
+				? rawLabels.en.trim()
+				: typeof rawLabels === 'string'
+					? rawLabels.trim()
+					: id
+		const es =
+			typeof rawLabels?.es === 'string' ? rawLabels.es.trim() : en || id
+		if (!en && !es) continue
+		map[id] = { en: en || id, es: es || en || id }
+	}
+	return map
+}
+
+/**
+ * Merges admin-default labels with agency custom labels.
+ * Defaults always win for required ids; agency entries only apply to custom tags.
+ *
+ * @param {Record<string, TagLabels>|undefined|null} defaultsMap
+ * @param {Record<string, TagLabels>|undefined|null} agencyLabels
+ * @returns {Record<string, TagLabels>}
+ */
+export function mergeTagLabelMaps(defaultsMap, agencyLabels) {
+	const defaults = defaultsMap || {}
+	/** @type {Set<string>} */
+	const requiredIds = new Set(
+		Object.keys(defaults).map((id) => canonicalizeTagId(id)).filter(Boolean),
+	)
+	/** @type {Record<string, TagLabels>} */
+	const customOnly = {}
+	for (const [id, labels] of Object.entries(
+		normalizeAgencyLabelMap(agencyLabels),
+	)) {
+		if (requiredIds.has(canonicalizeTagId(id))) continue
+		customOnly[id] = labels
+	}
+	return { ...defaults, ...customOnly }
+}
+
+/**
+ * Loads a display label map for an agency tags document id (defaults + custom).
+ *
+ * @param {string|undefined|null} agencyId
+ * @returns {Promise<Record<string, TagLabels>>}
+ */
+export async function fetchMergedTagLabelMapForAgencyId(agencyId) {
+	const defaults = await fetchTagDefaults()
+	if (!agencyId) return buildTagLabelMap(defaults)
+	const snap = await getDoc(doc(db, 'tags', agencyId))
+	if (!snap.exists()) return buildTagLabelMap(defaults)
+	return buildMergedAgencyTagLabelMap(defaults, snap.data())
+}
+
+/**
+ * Builds a merged label map for one agency tags doc + global defaults.
+ *
+ * @param {TagDefaults} defaults
+ * @param {{ Topic?: { labels?: Record<string, TagLabels> }, Source?: { labels?: Record<string, TagLabels> } }|undefined|null} agencyTagsDoc
+ * @returns {Record<string, TagLabels>}
+ */
+export function buildMergedAgencyTagLabelMap(defaults, agencyTagsDoc) {
+	const defaultsMap = buildTagLabelMap(defaults)
+	const topicLabels = normalizeAgencyLabelMap(agencyTagsDoc?.Topic?.labels)
+	const sourceLabels = normalizeAgencyLabelMap(agencyTagsDoc?.Source?.labels)
+	return mergeTagLabelMaps(defaultsMap, { ...topicLabels, ...sourceLabels })
+}
+
+/**
+ * Updates labels map when renaming a custom tag id.
+ *
+ * @param {Record<string, TagLabels>} labels
+ * @param {string} oldId
+ * @param {string} newId
+ * @param {TagLabels} nextLabels
+ * @returns {Record<string, TagLabels>}
+ */
+export function renameAgencyTagInLabelMap(labels, oldId, newId, nextLabels) {
+	const next = { ...(labels || {}) }
+	const from = canonicalizeTagId(oldId)
+	const to = canonicalizeTagId(newId)
+	if (from && from !== 'Other') delete next[from]
+	if (to && to !== 'Other') {
+		next[to] = {
+			en: nextLabels?.en?.trim() || to,
+			es: nextLabels?.es?.trim() || nextLabels?.en?.trim() || to,
+		}
+	}
+	return next
+}
+
+/**
+ * Removes a custom tag id from the labels map.
+ *
+ * @param {Record<string, TagLabels>} labels
+ * @param {string} id
+ * @returns {Record<string, TagLabels>}
+ */
+export function removeAgencyTagFromLabelMap(labels, id) {
+	const next = { ...(labels || {}) }
+	const key = canonicalizeTagId(id)
+	if (key) delete next[key]
+	return next
+}
+
+/**
  * Display label for a tag id.
  *
  * @param {{
@@ -356,8 +473,8 @@ export async function buildAgencyTagsPayload(defaults) {
 	const topics = getRequiredIds(resolved, 'Topic')
 	const sources = getRequiredIds(resolved, 'Source')
 	return {
-		Topic: { list: [...topics], active: [...topics] },
-		Source: { list: [...sources], active: [...sources] },
+		Topic: { list: [...topics], active: [...topics], labels: {} },
+		Source: { list: [...sources], active: [...sources], labels: {} },
 		Labels: {
 			list: [...DEFAULT_AGENCY_LABELS],
 			active: [...DEFAULT_AGENCY_LABELS],


### PR DESCRIPTION
Spanish report UIs were showing mixed English tag names because only a few strings were translated. This branch stores EN/ES labels for admin defaults and agency custom tags, keeps English ids on reports, and shows the right language in pickers and report details.

**Changes**
- Admin Global Tag Defaults: add/edit Topic and Source with English id + required EN/ES labels; save/propagate to agencies
- Normalize Other aliases (`Other/Otro` → `Other`) from admin tools
- Agency Tagging: custom tags use id + EN/ES; labels live in `Topic.labels` / `Source.labels`; `list`/`active` stay English ids
- Public and agency report pickers merge admin defaults with agency labels so `/es/report` shows Spanish
- Agency “Other” → catalog requires an ES label for new tags; report stores the English id
- Report modal and report detail page use the same merged label map
- Agency labels cannot override required admin default ids