### PR TITLE
Feat/agency scoped firestore rules

### DIFF
--- a/components/admin/ExperimentSettings.jsx
+++ b/components/admin/ExperimentSettings.jsx
@@ -49,6 +49,7 @@ function getExperimentFunctions() {
 			fn,
 			'backfillReportExperimentFields',
 		),
+		backfillAgencyClaims: httpsCallable(fn, 'backfillAgencyClaims'),
 		getExperimentMetrics: httpsCallable(fn, 'getExperimentMetrics'),
 	}
 }
@@ -202,6 +203,32 @@ const ExperimentSettings = () => {
 		}
 	}
 
+	const handleBackfillAgencyClaims = async (dryRun) => {
+		if (
+			!window.confirm(
+				dryRun
+					? 'Dry-run: count agency users that need agencyId claims restamped?'
+					: 'Re-stamp agencyId/agencyName Auth claims for every email in agencyUsers? Users must refresh their session afterward.',
+			)
+		) {
+			return
+		}
+		setBusy(true)
+		setStatus('')
+		try {
+			const { backfillAgencyClaims } = getExperimentFunctions()
+			const result = await backfillAgencyClaims({ dryRun })
+			const d = result.data || {}
+			setStatus(
+				`${dryRun ? 'Dry-run' : 'Claims backfill'}: updated ${d.updated}, skipped ${d.skipped}, missingAuth ${d.missingAuth}, emails ${d.emailCount}.`,
+			)
+		} catch (err) {
+			setStatus(formatCallableError(err, 'Agency claims backfill failed.'))
+		} finally {
+			setBusy(false)
+		}
+	}
+
 	if (!config) {
 		return (
 			<div className="mb-8 p-4 bg-white rounded-lg">
@@ -339,6 +366,21 @@ const ExperimentSettings = () => {
 						disabled={busy}
 						onClick={handleBackfill}>
 						Initialize experiment fields
+					</Button>
+					<Button
+						size="sm"
+						variant="outlined"
+						disabled={busy}
+						onClick={() => handleBackfillAgencyClaims(true)}>
+						Dry-run agency claims
+					</Button>
+					<Button
+						size="sm"
+						color="blue"
+						variant="outlined"
+						disabled={busy}
+						onClick={() => handleBackfillAgencyClaims(false)}>
+						Backfill agency claims
 					</Button>
 				</div>
 				{previewCount !== null && (

--- a/components/admin/Users.jsx
+++ b/components/admin/Users.jsx
@@ -1003,9 +1003,32 @@ const Users = () => {
 						// Append the user's email to the new agency's agencyUsers array
 						const updatedNewAgencyUsers = [...newAgencyUsers, email]
 						await updateDoc(newDocRef, { agencyUsers: updatedNewAgencyUsers })
+						// Refresh Auth claims so rules/queries see the new agencyId
+						try {
+							await addAgencyRole({
+								email,
+								agencyId: selectedAgency.id,
+							})
+						} catch (claimError) {
+							console.error(
+								'Agency membership updated but claim refresh failed:',
+								claimError,
+							)
+						}
 						console.log('User successfully added to the new agency.')
 					} else {
 						console.log('User already exists in this agency.')
+						try {
+							await addAgencyRole({
+								email,
+								agencyId: selectedAgency.id,
+							})
+						} catch (claimError) {
+							console.error(
+								'Failed to refresh agency claims for existing membership:',
+								claimError,
+							)
+						}
 					}
 				} else {
 					console.log('Agency document does not exist.')
@@ -1196,8 +1219,11 @@ const Users = () => {
 			} else if (userRole === 'Agency') {
 				// Call the addAgencyRole function
 				try {
-					// Switch user's mobileUsers/doc/userRole to "Agency"
-					await addAgencyRole({ email: email })
+					if (!selectedAgency) {
+						throw new Error('Select an agency before assigning the Agency role.')
+					}
+					// Stamp claims with agencyId first (callable accepts preferred agencyId)
+					await addAgencyRole({ email: email, agencyId: selectedAgency })
 					// Add user's email to the selected agency's document
 					await addUserToAgency(email, selectedAgency) // Ensure `selectedAgency` is the actual document ID of the agency
 				} catch (error) {

--- a/components/analytics/ComparisonGraphPlotted.jsx
+++ b/components/analytics/ComparisonGraphPlotted.jsx
@@ -35,7 +35,7 @@ import {
   Legend,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import { collection, query, where, getDocs, Timestamp } from "firebase/firestore";
+import { collection, query, where, getDocs, getDoc, doc, Timestamp } from "firebase/firestore";
 import { db } from '../../config/firebase'
 import {
   buildActiveReportsQuery,
@@ -80,6 +80,7 @@ const ComparisonGraphPlotted = ({dateRange, setDateRange, selectedTopics, setSel
 
   // --- User/role state ---
   const [agencyName, setAgencyName] = useState("") // Name of the current agency (if applicable)
+  const [agencyId, setAgencyId] = useState("") // Firestore agency doc id
   const [privilege, setPrivilege] = useState(null) // User privilege level
   const [checkRole, setCheckRole] = useState(false) // Triggers role check
   const { user, verifyRole } = useAuth() // Auth context
@@ -169,7 +170,7 @@ const ComparisonGraphPlotted = ({dateRange, setDateRange, selectedTopics, setSel
 
     const experimentConfig = await fetchExperimentConfig()
     const activeExperimentId = getActiveExperimentId(experimentConfig)
-    const agencyFilter = privilege === 'Agency' ? agencyName : undefined
+    const agencyIdFilter = privilege === 'Agency' ? agencyId : undefined
 
     // Stores the number of times that the topic was reported for each day within timeline
     const topicArray = []
@@ -183,7 +184,7 @@ const ComparisonGraphPlotted = ({dateRange, setDateRange, selectedTopics, setSel
           topic: selectedTopics[topic].value,
           dateFrom: array[0][index],
           dateTo: array[0][index + 1],
-          agency: agencyFilter,
+          agencyId: agencyIdFilter,
           activeExperimentId,
         })
         const dailyReports = await getDocs(queryDaily);
@@ -246,24 +247,32 @@ const ComparisonGraphPlotted = ({dateRange, setDateRange, selectedTopics, setSel
 
 
   useEffect(()=> {
-      verifyRole().then((result) => {
-        
-        // console.log("Current user information " + result.admin)
+      verifyRole().then(async (result) => {
         if (result.agency) {
-          let agencyTempName;
-          const agencyCollection = collection(db,"agency")
-          const q = query(agencyCollection, where('agencyUsers', "array-contains", user['email']));
-          getDocs(q).then((querySnapshot) => {
-          querySnapshot.forEach((doc) => { // Set initial values
-            agencyTempName = doc.data()['name']
+          if (result.agencyId) {
             setPrivilege("Agency")
-            setAgencyName(agencyTempName)
-          
+            setAgencyId(result.agencyId)
+            setAgencyName(result.agencyName || result.agencyId)
+            if (!result.agencyName) {
+              const agencyDoc = await getDoc(doc(db, "agency", result.agencyId))
+              if (agencyDoc.exists()) {
+                setAgencyName(agencyDoc.data()?.name || result.agencyId)
+              }
+            }
+          } else {
+            const agencyCollection = collection(db,"agency")
+            const q = query(agencyCollection, where('agencyUsers', "array-contains", user['email']));
+            const querySnapshot = await getDocs(q)
+            querySnapshot.forEach((docSnap) => {
+              setPrivilege("Agency")
+              setAgencyName(docSnap.data()['name'])
+              setAgencyId(docSnap.id)
             })
-          })
+          }
         } else if (result.admin) {
           setPrivilege("Admin")
           setAgencyName("")
+          setAgencyId("")
         }
   
         setCheckRole(true)

--- a/components/dashboard/TagGraph.jsx
+++ b/components/dashboard/TagGraph.jsx
@@ -116,16 +116,26 @@ const TagGraph = () => {
 			const result = await verifyRole()
 			
 			if (result.agency) {
-				// Fetch agency information for agency users
+				if (result.agencyId) {
+					setAgencyId(result.agencyId)
+					setAgencyName(result.agencyName || result.agencyId)
+					setPrivilege("Agency")
+					if (!result.agencyName) {
+						const agencyDoc = await getDoc(doc(db, "agency", result.agencyId))
+						if (agencyDoc.exists()) {
+							setAgencyName(agencyDoc.data()?.name || result.agencyId)
+						}
+					}
+					return
+				}
+				// Legacy tokens without agencyId: membership lookup
 				const agencyCollection = collection(db, "agency")
 				const q = query(agencyCollection, where('agencyUsers', "array-contains", user['email']))
 				const querySnapshot = await getDocs(q)
 				
-				querySnapshot.forEach((doc) => {
-					const agencyTempName = doc.data()['name']
-					const agencyTempId = doc.id
-					setAgencyName(agencyTempName)
-					setAgencyId(agencyTempId)
+				querySnapshot.forEach((docSnap) => {
+					setAgencyName(docSnap.data()['name'])
+					setAgencyId(docSnap.id)
 					setPrivilege("Agency")
 				})
 			} else if (result.admin) {
@@ -188,14 +198,14 @@ const TagGraph = () => {
 
 		// Process each topic for different time periods
 		for (let index = 0; index < tempTopics.length; index++) {
-			const agencyFilter =
-				privilege === 'Agency' ? agencyName : undefined
+			const agencyIdFilter =
+				privilege === 'Agency' ? agencyId : undefined
 
 			const queryYesterday = buildActiveReportsQuery({
 				topic: tempTopics[index],
 				dateFrom: getStartOfDay(1),
 				dateTo: getEndOfDay(),
-				agency: agencyFilter,
+				agencyId: agencyIdFilter,
 				activeExperimentId,
 			})
 			const dataYesterday = await getDocs(queryYesterday)
@@ -204,7 +214,7 @@ const TagGraph = () => {
 				topic: tempTopics[index],
 				dateFrom: getStartOfDay(3),
 				dateTo: getEndOfDay(),
-				agency: agencyFilter,
+				agencyId: agencyIdFilter,
 				activeExperimentId,
 			})
 			const dataThreeDays = await getDocs(queryThreeDays)
@@ -213,7 +223,7 @@ const TagGraph = () => {
 				topic: tempTopics[index],
 				dateFrom: getStartOfDay(7),
 				dateTo: getEndOfDay(),
-				agency: agencyFilter,
+				agencyId: agencyIdFilter,
 				activeExperimentId,
 			})
 			const dataSevenDays = await getDocs(querySevenDays)
@@ -270,7 +280,7 @@ const TagGraph = () => {
 		if (privilege) {
 			setCheckRole(true)
 		}
-	}, [agencyName, privilege])
+	}, [agencyId, privilege])
 
 	/**
 	 * Effect hook to fetch topic reports after role verification.

--- a/components/layout/Headbar.jsx
+++ b/components/layout/Headbar.jsx
@@ -19,7 +19,7 @@
 import React, { useState, useEffect } from 'react'
 import { AiOutlineSearch } from 'react-icons/ai'
 import { GiMagnifyingGlass } from "react-icons/gi";
-import { collection, getDocs, query, where } from 'firebase/firestore'
+import { collection, getDocs, getDoc, doc, query, where } from 'firebase/firestore'
 import { useAuth } from '../../context/AuthContext'
 import { db } from "../../config/firebase"
 import Image from 'next/image'
@@ -58,13 +58,34 @@ const Headbar = ({ search, setSearch}) => {
      * @throws {Error} When Firestore query fails
      */
     const getData = async () => {
+        const applyAgencyDoc = (agencyData) => {
+            if (!agencyData) return
+            setTitle(agencyData.name || '')
+            const logo = agencyData.logo
+            if (Array.isArray(logo) && logo[0]) {
+                setAgencyLogo(logo[0])
+            }
+        }
+
+        if (customClaims?.agencyId) {
+            const agencySnap = await getDoc(doc(db, 'agency', customClaims.agencyId))
+            if (agencySnap.exists()) {
+                applyAgencyDoc(agencySnap.data())
+                return
+            }
+        }
+
+        // Legacy tokens without agencyId: membership lookup
+        if (!user?.email) return
         const agencyCollection = collection(db, 'agency')
-        const q = query(agencyCollection, where('agencyUsers', "array-contains", user['email']));
+        const q = query(
+            agencyCollection,
+            where('agencyUsers', 'array-contains', user.email),
+        )
         const querySnapshot = await getDocs(q)
-        querySnapshot.forEach((doc) => {
-            setTitle(doc.data()['name'])
-            setAgencyLogo(doc.data()['logo'][0])
-        });
+        querySnapshot.forEach((agencyDoc) => {
+            applyAgencyDoc(agencyDoc.data())
+        })
     }
     
     /**
@@ -96,7 +117,7 @@ const Headbar = ({ search, setSearch}) => {
      */
     useEffect(() => {
         getData()
-    }, [])
+    }, [customClaims?.agencyId, user?.email])
 
     /**
      * Renders the appropriate title and subtitle based on user role.

--- a/components/modals/reports/AgencyReportModal.jsx
+++ b/components/modals/reports/AgencyReportModal.jsx
@@ -7,6 +7,7 @@ import { db } from '../../../config/firebase'
 import {
 	fetchExperimentConfig,
 	getActiveExperimentId,
+	newReportAgencyFields,
 	newReportExperimentFields,
 } from '../../../utils/reports-queries'
 import {
@@ -398,11 +399,17 @@ const AgencyReportModal = ({
 		const experimentConfig = await fetchExperimentConfig()
 		const experimentId = getActiveExperimentId(experimentConfig)
 		const resolvedLabel = resolveReportLabel()
+		if (!selectedAgencyId) {
+			throw new Error('Agency id is required before creating a report')
+		}
 		await addDoc(dbInstance, {
 			userID: user.accountId,
 			state: data.state.name,
 			city: data.city == null ? 'N/A' : data.city.name,
-			agency: selectedAgency,
+			...newReportAgencyFields({
+				agencyName: selectedAgency,
+				agencyId: selectedAgencyId,
+			}),
 			title: title,
 			link: link,
 			secondLink: secondLink,
@@ -1022,8 +1029,8 @@ const AgencyReportModal = ({
 	useEffect(() => {
 		if (selectedAgency) {
 			getTopicList()
+			getAllTags()
 		}
-		getAllTags()
 	}, [selectedAgency])
 
 	/**

--- a/components/modals/reports/AgencyReportModal.jsx
+++ b/components/modals/reports/AgencyReportModal.jsx
@@ -1022,8 +1022,8 @@ const AgencyReportModal = ({
 	useEffect(() => {
 		if (selectedAgency) {
 			getTopicList()
-			getAllTags()
 		}
+		getAllTags()
 	}, [selectedAgency])
 
 	/**
@@ -1126,6 +1126,7 @@ const AgencyReportModal = ({
 			setAgencyLabelColors({})
 			setTopicLabels({})
 			setSourceLabels({})
+			setTagLabelMap({})
 		} else {
 			const defaults = await fetchTagDefaults()
 			const docRef = doc(db, 'tags', selectedAgencyId)

--- a/components/reports/ReportSystem.jsx
+++ b/components/reports/ReportSystem.jsx
@@ -42,6 +42,7 @@ import { db } from "../../config/firebase"
 import {
 	fetchExperimentConfig,
 	getActiveExperimentId,
+	newReportAgencyFields,
 	newReportExperimentFields,
 } from "../../utils/reports-queries"
 import {
@@ -570,6 +571,14 @@ const ReportSystem = ({
 		try {
 			const experimentConfig = await fetchExperimentConfig()
 			const experimentId = getActiveExperimentId(experimentConfig)
+			if (!agencyID) {
+				console.error("Cannot save report without agencyId")
+				setErrors((prev) => ({
+					...prev,
+					agency: "Agency is required",
+				}))
+				return
+			}
 			// Snapshot reporter location from their profile (public flow has no city/state picker)
 			const city =
 				formatLocationPart(userData?.city) || 'N/A'
@@ -577,7 +586,10 @@ const ReportSystem = ({
 			const reportData = {
 				userID: user.accountId,
 				email: user.email,
-				agency: selectedAgency,
+				...newReportAgencyFields({
+					agencyName: selectedAgency,
+					agencyId: agencyID,
+				}),
 				topic: isOtherTagName(selectedTopic) ? otherTopic : selectedTopic,
 				// `hearFrom` matches the established schema: tags.{agency}.Source.active -> reports.hearFrom.
 				hearFrom: isOtherTagName(selectedSource) ? otherSource : selectedSource,
@@ -604,6 +616,7 @@ const ReportSystem = ({
 				logEvent(analytics, 'report_submitted', {
 					user_id: user.accountId,
 					agency: selectedAgency,
+					agencyId: agencyID,
 					topic: selectedTopic
 				})
 			}

--- a/components/reports/ReportsSection.jsx
+++ b/components/reports/ReportsSection.jsx
@@ -43,6 +43,7 @@ import {
 	fetchExperimentConfig,
 	fetchReportsFromQuery,
 	getActiveExperimentId,
+	newReportAgencyFields,
 	newReportExperimentFields,
 } from '../../utils/reports-queries'
 import {
@@ -387,29 +388,41 @@ const ReportsSection = ({
 			setActiveExperimentId(experimentId)
 
 			if (isAgency) {
-				if (!user?.email) {
+				if (!user?.email && !customClaims?.agencyId) {
 					console.error(
-						'Agency user missing email; refusing unscoped report fetch',
+						'Agency user missing email/agencyId; refusing unscoped report fetch',
 					)
 					if (!isStale()) applyEmptyReportsState()
 					return
 				}
 
-				// Agency user: fetch reports for their specific agency only
-				const agencyQuery = query(
-					collection(db, 'agency'),
-					where('agencyUsers', 'array-contains', user.email),
-				)
-				const agencySnapshot = await getDocs(agencyQuery)
-				if (isStale()) return
+				// Prefer Auth claim agencyId (server-stamped); fall back to membership lookup
+				if (customClaims?.agencyId) {
+					resolvedAgencyId = customClaims.agencyId
+					resolvedAgencyName = customClaims.agencyName || ''
+					if (!resolvedAgencyName) {
+						const agencyDoc = await getDoc(doc(db, 'agency', resolvedAgencyId))
+						if (isStale()) return
+						if (agencyDoc.exists()) {
+							resolvedAgencyName = agencyDoc.data()?.name || ''
+						}
+					}
+				} else if (user?.email) {
+					const agencyQuery = query(
+						collection(db, 'agency'),
+						where('agencyUsers', 'array-contains', user.email),
+					)
+					const agencySnapshot = await getDocs(agencyQuery)
+					if (isStale()) return
 
-				agencySnapshot.forEach((agencyDoc) => {
-					resolvedAgencyName = agencyDoc.data().name
-					resolvedAgencyId = agencyDoc.id
-				})
+					agencySnapshot.forEach((agencyDoc) => {
+						resolvedAgencyName = agencyDoc.data().name
+						resolvedAgencyId = agencyDoc.id
+					})
+				}
 
-				// Empty agency name would skip the Firestore agency constraint and return all reports
-				if (!resolvedAgencyName || !resolvedAgencyId) {
+				// Empty agency id would skip the Firestore agency constraint and return all reports
+				if (!resolvedAgencyId) {
 					console.error(
 						'Agency user has no agency membership; refusing unscoped report fetch',
 					)
@@ -417,9 +430,13 @@ const ReportsSection = ({
 					return
 				}
 
+				if (!resolvedAgencyName) {
+					resolvedAgencyName = resolvedAgencyId
+				}
+
 				reportArr = await fetchReportsFromQuery(
 					buildActiveReportsQuery({
-						agency: resolvedAgencyName,
+						agencyId: resolvedAgencyId,
 						activeExperimentId: experimentId,
 						includeArchived: false,
 					}),
@@ -1071,6 +1088,7 @@ const ReportsSection = ({
 
 				for (const row of data) {
 					let agencyName = ''
+					let matchedAgencyId = ''
 					if (row.state && row.agency) {
 						const agencyQuery = query(
 							collection(db, 'agency'),
@@ -1079,25 +1097,36 @@ const ReportsSection = ({
 						const agencySnapshot = await getDocs(agencyQuery)
 
 						// Find agency with a name containing the CSV agency name (case-insensitive)
-						agencySnapshot.forEach((doc) => {
-							const fullAgencyName = doc.data().name.toLowerCase()
+						agencySnapshot.forEach((agencyDoc) => {
+							const fullAgencyName = agencyDoc.data().name.toLowerCase()
 							const csvAgencyName = row.agency.toLowerCase()
 
 							if (fullAgencyName.includes(csvAgencyName)) {
-								agencyName = doc.data().name // Use the full agency name from Firestore
+								agencyName = agencyDoc.data().name // Use the full agency name from Firestore
+								matchedAgencyId = agencyDoc.id
 							}
 						})
 
-						if (!agencyName) {
+						if (!agencyName || !matchedAgencyId) {
 							console.warn(
 								`No matching agency found for state: ${row.state} and partial name: ${row.agency}`,
 							)
 						}
 					}
 
-					// Format row with correct types, and assign matched agency name
+					if (!matchedAgencyId) {
+						console.warn(
+							`Skipping CSV row without agencyId (title: ${row.title || 'untitled'})`,
+						)
+						continue
+					}
+
+					// Format row with correct types, and assign matched agency name + id
 					const formattedRow = {
-						agency: agencyName, // Full agency name if found, otherwise empty string
+						...newReportAgencyFields({
+							agencyName,
+							agencyId: matchedAgencyId,
+						}),
 						city: String(row.city || ''),
 						createdDate: row.createdDate
 							? Timestamp.fromDate(new Date(row.createdDate))

--- a/context/AuthContext.jsx
+++ b/context/AuthContext.jsx
@@ -73,7 +73,49 @@ export const AuthContextProvider = ({children}) => {
     const [user, setUser] = useState(null)
     const [loading, setLoading] = useState(true)
     const [userRole, setUserRole] = useState('user')
-    const [customClaims, setCustomClaims] = useState({agency: false, admin: false})
+    const [customClaims, setCustomClaims] = useState({
+        agency: false,
+        admin: false,
+        agencyId: null,
+        agencyName: null,
+    })
+
+    /**
+     * Normalizes Auth token claims into the shape the app consumes.
+     *
+     * @param {Record<string, unknown>|undefined|null} claims
+     * @returns {{admin: boolean, agency: boolean, agencyId: string|null, agencyName: string|null}}
+     */
+    const normalizeCustomClaims = (claims) => {
+        if (claims?.admin) {
+            return {
+                admin: true,
+                agency: false,
+                agencyId: null,
+                agencyName: null,
+            }
+        }
+        if (claims?.agency) {
+            return {
+                admin: false,
+                agency: true,
+                agencyId:
+                    typeof claims.agencyId === 'string' && claims.agencyId
+                        ? claims.agencyId
+                        : null,
+                agencyName:
+                    typeof claims.agencyName === 'string' && claims.agencyName
+                        ? claims.agencyName
+                        : null,
+            }
+        }
+        return {
+            admin: false,
+            agency: false,
+            agencyId: null,
+            agencyName: null,
+        }
+    }
 
     // Functions instance created on the client so callables work (avoids null during SSR).
     // If the SDK throws "Service functions is not available" (e.g. in some Next.js/build envs), we degrade gracefully.
@@ -130,17 +172,10 @@ export const AuthContextProvider = ({children}) => {
                 })
                 localStorage.setItem("userId", localId)
                 
-                // Verify user's custom claims for role-based access
+                // Verify user's custom claims for role-based access (includes agencyId)
                 user.getIdTokenResult(true)
                     .then((idTokenResult) => {
-                        // Set custom claims based on user's role
-                        if (!!idTokenResult.claims.admin) {
-                            setCustomClaims({admin: true})
-                        } else if (!!idTokenResult.claims.agency) {
-                            setCustomClaims({agency: true})
-                        } else {
-                            setCustomClaims({agency: false, admin: false})
-                        }
+                        setCustomClaims(normalizeCustomClaims(idTokenResult.claims))
                     })
                     .catch((error) => {
                         console.log("Error fetching custom claims:", error);
@@ -149,7 +184,7 @@ export const AuthContextProvider = ({children}) => {
             } else {
                 // Clear user state when signed out
                 setUser(null)
-                setCustomClaims({agency: false, admin: false})
+                setCustomClaims(normalizeCustomClaims(null))
             }
             setLoading(false)
         })
@@ -163,6 +198,7 @@ export const AuthContextProvider = ({children}) => {
             return {
                 addAdminRole: noopCallable,
                 addAgencyRole: noopCallable,
+                backfillAgencyClaims: noopCallable,
                 viewRole: noopCallable,
                 addUserRole: noopCallable,
                 getUserByEmail: noopCallable,
@@ -175,6 +211,10 @@ export const AuthContextProvider = ({children}) => {
         return {
             addAdminRole: httpsCallable(functionsInstance, 'addAdminRole'),
             addAgencyRole: httpsCallable(functionsInstance, 'addAgencyRole'),
+            backfillAgencyClaims: httpsCallable(
+                functionsInstance,
+                'backfillAgencyClaims',
+            ),
             viewRole: httpsCallable(functionsInstance, 'viewRole'),
             addUserRole: httpsCallable(functionsInstance, 'addUserRole'),
             getUserByEmail: httpsCallable(functionsInstance, 'getUserByEmail'),
@@ -477,6 +517,7 @@ export const AuthContextProvider = ({children}) => {
             sendSignIn,
             addAdminRole: callables.addAdminRole,
             addAgencyRole: callables.addAgencyRole,
+            backfillAgencyClaims: callables.backfillAgencyClaims,
             verifyRole,
             viewRole: callables.viewRole,
             addUserRole: callables.addUserRole,

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -33,6 +33,16 @@
       "fields": [
         { "fieldPath": "archived", "order": "ASCENDING" },
         { "fieldPath": "experimentId", "order": "ASCENDING" },
+        { "fieldPath": "agencyId", "order": "ASCENDING" },
+        { "fieldPath": "createdDate", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reports",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "archived", "order": "ASCENDING" },
+        { "fieldPath": "experimentId", "order": "ASCENDING" },
         { "fieldPath": "topic", "order": "ASCENDING" },
         { "fieldPath": "createdDate", "order": "ASCENDING" }
       ]
@@ -54,6 +64,17 @@
       "fields": [
         { "fieldPath": "archived", "order": "ASCENDING" },
         { "fieldPath": "experimentId", "order": "ASCENDING" },
+        { "fieldPath": "topic", "order": "ASCENDING" },
+        { "fieldPath": "agencyId", "order": "ASCENDING" },
+        { "fieldPath": "createdDate", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reports",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "archived", "order": "ASCENDING" },
+        { "fieldPath": "experimentId", "order": "ASCENDING" },
         { "fieldPath": "userID", "order": "ASCENDING" }
       ]
     },
@@ -64,6 +85,15 @@
         { "fieldPath": "archived", "order": "ASCENDING" },
         { "fieldPath": "experimentId", "order": "ASCENDING" },
         { "fieldPath": "agency", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reports",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "archived", "order": "ASCENDING" },
+        { "fieldPath": "experimentId", "order": "ASCENDING" },
+        { "fieldPath": "agencyId", "order": "ASCENDING" }
       ]
     },
     {

--- a/firestore.rules
+++ b/firestore.rules
@@ -7,7 +7,29 @@ service cloud.firestore {
     }
 
     function isAdmin() {
-      return isSignedIn() && request.auth.token.admin == true;
+      return isSignedIn() && request.auth.token.get('admin', false) == true;
+    }
+
+    function isAgencyUser() {
+      return isSignedIn()
+        && request.auth.token.get('agency', false) == true
+        && request.auth.token.get('agencyId', '') is string
+        && request.auth.token.get('agencyId', '').size() > 0;
+    }
+
+    function sameAgency() {
+      return isAgencyUser()
+        && resource.data.agencyId == request.auth.token.agencyId;
+    }
+
+    function sameAgencyOnCreate() {
+      return isAgencyUser()
+        && request.resource.data.agencyId == request.auth.token.agencyId;
+    }
+
+    function hasValidAgencyId() {
+      return request.resource.data.agencyId is string
+        && request.resource.data.agencyId.size() > 0;
     }
 
     function archiveFieldsChanged() {
@@ -20,22 +42,67 @@ service cloud.firestore {
       allow write: if isAdmin();
     }
 
-    match /reports/{reportId} {
+    match /tagSystems/{docId} {
       allow read: if isSignedIn();
+      allow write: if isAdmin();
+    }
+
+    match /locations/{docId} {
+      allow read: if isSignedIn();
+      allow write: if isAdmin();
+    }
+
+    // Community/public submitters need to list agencies for /report.
+    // Agency-claim users may only read their own agency doc (avoids cross-agency agencyUsers leaks).
+    match /agency/{agencyId} {
+      allow read: if isAdmin()
+        || (isAgencyUser() && agencyId == request.auth.token.agencyId)
+        || (isSignedIn() && request.auth.token.get('agency', false) != true);
+      allow create, update, delete: if isAdmin();
+    }
+
+    match /tags/{agencyDocId} {
+      // Public /report loads the selected agency's Topic/Source pickers.
+      allow read: if isSignedIn();
+      allow write: if isAdmin()
+        || (isAgencyUser() && agencyDocId == request.auth.token.agencyId);
+    }
+
+    match /mobileUsers/{userId} {
+      // Agency triage needs reporter profiles; community users only their own doc.
+      allow read: if isAdmin()
+        || isAgencyUser()
+        || (isSignedIn() && request.auth.uid == userId);
+      allow create, update: if isAdmin()
+        || (isSignedIn() && request.auth.uid == userId);
+      allow delete: if isAdmin();
+    }
+
+    match /helpRequests/{requestId} {
+      allow create: if isSignedIn();
+      allow read, update, delete: if isAdmin();
+    }
+
+    match /reports/{reportId} {
+      allow read: if isAdmin()
+        || sameAgency()
+        || (isSignedIn() && resource.data.userID == request.auth.uid);
 
       allow create: if isSignedIn()
         && request.resource.data.archived == false
         && request.resource.data.experimentId is string
-        && request.resource.data.experimentId.size() > 0;
+        && request.resource.data.experimentId.size() > 0
+        && hasValidAgencyId()
+        && (
+          isAdmin()
+          || sameAgencyOnCreate()
+          || request.auth.token.get('agency', false) != true
+        );
 
-      allow update: if isSignedIn()
-        && (!archiveFieldsChanged() || isAdmin());
+      allow update: if isAdmin()
+        || (sameAgency() && !archiveFieldsChanged());
 
-      allow delete: if isSignedIn();
-    }
-
-    match /{document=**} {
-      allow read, write: if isSignedIn();
+      allow delete: if isAdmin() || sameAgency();
     }
   }
 }

--- a/functions/agency-claims.js
+++ b/functions/agency-claims.js
@@ -1,0 +1,204 @@
+/**
+ * Agency Auth claim helpers: stamp agencyId / agencyName on agency users.
+ */
+
+const functions = require("firebase-functions/v1");
+const admin = require("firebase-admin");
+const {log} = require("firebase-functions/logger");
+
+/**
+ * @param {import("firebase-functions/v1").https.CallableContext} context
+ */
+function requireAdmin(context) {
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+        "unauthenticated",
+        "Must be signed in.",
+    );
+  }
+  if (!context.auth.token.admin) {
+    throw new functions.https.HttpsError(
+        "permission-denied",
+        "Admin privileges required.",
+    );
+  }
+}
+
+/**
+ * Resolves agency doc id + name for an email (and optional preferred agencyId).
+ *
+ * @param {string} email
+ * @param {string} [preferredAgencyId]
+ * @returns {Promise<{agencyId: string, agencyName: string}|null>}
+ */
+async function resolveAgencyMembership(email, preferredAgencyId) {
+  const db = admin.firestore();
+  const preferred =
+    typeof preferredAgencyId === "string" ? preferredAgencyId.trim() : "";
+
+  if (preferred) {
+    const snap = await db.collection("agency").doc(preferred).get();
+    if (snap.exists) {
+      return {
+        agencyId: snap.id,
+        agencyName: String(snap.data()?.name || ""),
+      };
+    }
+  }
+
+  const querySnap = await db
+      .collection("agency")
+      .where("agencyUsers", "array-contains", email)
+      .limit(1)
+      .get();
+
+  if (querySnap.empty) {
+    return null;
+  }
+
+  const docSnap = querySnap.docs[0];
+  return {
+    agencyId: docSnap.id,
+    agencyName: String(docSnap.data()?.name || ""),
+  };
+}
+
+/**
+ * Sets Auth custom claims for an agency user.
+ *
+ * @param {string} uid
+ * @param {{agencyId: string, agencyName: string}} membership
+ * @returns {Promise<void>}
+ */
+async function setAgencyClaims(uid, membership) {
+  await admin.auth().setCustomUserClaims(uid, {
+    agency: true,
+    agencyId: membership.agencyId,
+    agencyName: membership.agencyName || "",
+  });
+}
+
+/**
+ * Callable: grant agency role with agencyId (+ agencyName) on the Auth token.
+ *
+ * Accepts optional `agencyId` so claims can be stamped before/while the email
+ * is written into `agency.agencyUsers` (admin promote flow).
+ *
+ * @param {{email?: string, agencyId?: string}} data
+ */
+exports.addAgencyRole = functions.https.onCall(async (data, context) => {
+  const email = typeof data?.email === "string" ? data.email.trim() : "";
+  if (!email) {
+    log("addAgencyRole skipped: email not provided");
+    return {
+      message: "No email provided. Skipping agency role assignment.",
+    };
+  }
+
+  const preferredAgencyId =
+    typeof data?.agencyId === "string" ? data.agencyId.trim() : "";
+
+  try {
+    const user = await admin.auth().getUserByEmail(email);
+    const membership = await resolveAgencyMembership(email, preferredAgencyId);
+    if (!membership?.agencyId) {
+      throw new functions.https.HttpsError(
+          "failed-precondition",
+          `No agency membership found for ${email}. Pass agencyId or add the email to an agency first.`,
+      );
+    }
+
+    await setAgencyClaims(user.uid, membership);
+    return {
+      message: `Success! ${email} has been made an agency user`,
+      agencyId: membership.agencyId,
+      agencyName: membership.agencyName,
+    };
+  } catch (err) {
+    if (err instanceof functions.https.HttpsError) {
+      throw err;
+    }
+    log("addAgencyRole failed", err);
+    throw new functions.https.HttpsError(
+        "internal",
+        err?.message || "Failed to assign agency role.",
+    );
+  }
+});
+
+/**
+ * Admin callable: re-stamp agencyId/agencyName claims for every email currently
+ * listed in any agency.agencyUsers array.
+ *
+ * @param {{dryRun?: boolean}} data
+ */
+exports.backfillAgencyClaims = functions.https.onCall(async (data, context) => {
+  requireAdmin(context);
+  const dryRun = data?.dryRun === true;
+
+  const agenciesSnap = await admin.firestore().collection("agency").get();
+  /** @type {Map<string, {agencyId: string, agencyName: string}>} */
+  const emailToAgency = new Map();
+
+  agenciesSnap.docs.forEach((docSnap) => {
+    const name = String(docSnap.data()?.name || "");
+    const users = Array.isArray(docSnap.data()?.agencyUsers) ?
+      docSnap.data().agencyUsers :
+      [];
+    users.forEach((rawEmail) => {
+      const email =
+        typeof rawEmail === "string" ? rawEmail.trim().toLowerCase() : "";
+      if (!email) return;
+      // First agency wins if an email appears in multiple (should be rare)
+      if (!emailToAgency.has(email)) {
+        emailToAgency.set(email, {
+          agencyId: docSnap.id,
+          agencyName: name,
+        });
+      }
+    });
+  });
+
+  let updated = 0;
+  let skipped = 0;
+  let missingAuth = 0;
+  /** @type {string[]} */
+  const errors = [];
+
+  for (const [email, membership] of emailToAgency.entries()) {
+    try {
+      const user = await admin.auth().getUserByEmail(email);
+      const existing = user.customClaims || {};
+      const already =
+        existing.agency === true &&
+        existing.agencyId === membership.agencyId &&
+        (existing.agencyName || "") === (membership.agencyName || "");
+
+      if (already) {
+        skipped += 1;
+        continue;
+      }
+
+      if (!dryRun) {
+        await setAgencyClaims(user.uid, membership);
+      }
+      updated += 1;
+    } catch (err) {
+      if (err?.code === "auth/user-not-found") {
+        missingAuth += 1;
+      } else {
+        errors.push(`${email}: ${err?.message || String(err)}`);
+      }
+    }
+  }
+
+  return {
+    dryRun,
+    agencyCount: agenciesSnap.size,
+    emailCount: emailToAgency.size,
+    updated,
+    skipped,
+    missingAuth,
+    errors,
+  };
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -244,81 +244,52 @@ exports.addAdminRole = functions.https.onCall((data, context) => {
   });
 });
 
+const agencyClaims = require("./agency-claims");
+
 /**
- * HTTP callable function to grant agency privileges to a user.
- * 
- * This function adds the 'agency' custom claim to a user, granting them
- * agency-level privileges for managing reports and content within their
- * assigned agency scope.
- * 
- * @param {Object} data - Function parameters
- * @param {string} data.email - The email address of the user to promote
- * @param {Object} context - Firebase function context
- * @returns {Promise<Object>} Success message or error
- * @throws {Error} When user lookup or claim update fails
+ * Grant agency privileges and stamp `agencyId` / `agencyName` on the Auth token.
+ * Optional `agencyId` lets admin promote before the email is in agencyUsers.
+ *
  * @example
- * const result = await addAgencyRole({ email: 'agency@example.com' });
+ * await addAgencyRole({ email: 'agency@example.com', agencyId: 'abc123' });
  */
-exports.addAgencyRole = functions.https.onCall(
-    (data, context) => {
-      // Validate email input before attempting to update auth
-      const email = typeof data?.email === "string" ? data.email.trim() : "";
-      if (!email) {
-        log("addAgencyRole skipped: email not provided");
-        return {
-          message: "No email provided. Skipping agency role assignment.",
-        };
-      }
+exports.addAgencyRole = agencyClaims.addAgencyRole;
 
-      // get user and add custom claim to user
-      return admin.auth().getUserByEmail(email).then((user) => {
-        // Once user object is retrieved, updates custom claim
-        return admin.auth().setCustomUserClaims(user.uid, {agency: true});
-
-        // callback for frontend if success
-      }).then(() => {
-        return {
-          message: `Success! ${email} has been made an agency admin`,
-        };
-
-        // callback if there is an error
-      }).catch((err) => {
-        return err;
-      });
-    });
+/**
+ * Admin-only: re-stamp agencyId/agencyName for every email in agencyUsers.
+ *
+ * @example
+ * await backfillAgencyClaims({ dryRun: true });
+ */
+exports.backfillAgencyClaims = agencyClaims.backfillAgencyClaims;
 
 /**
  * HTTP callable function to view a user's current role claims.
- * 
- * This function verifies an ID token and returns the user's current
- * custom claims, showing whether they have admin or agency privileges.
- * 
+ *
  * @param {Object} data - Function parameters
  * @param {string} data.id - The ID token to verify
- * @param {Object} context - Firebase function context
- * @returns {Promise<Object>} User's role claims
- * @throws {Error} When token verification fails
- * @example
- * const claims = await viewRole({ id: 'user-id-token' });
+ * @returns {Promise<Object>} User's role claims (admin/agency + agencyId when set)
  */
 exports.viewRole = functions.https.onCall((data, context) => {
-  // get user and add custom claim to user
   return admin
       .auth()
       .verifyIdToken(data.id)
       .then((decodedToken) => {
-        const claims = decodedToken.customClaims;
-        console.log(claims);
-        if (claims["admin"]) {
+        const claims = decodedToken;
+        if (claims.admin) {
           return {admin: true};
-        } else if (claims["agency"]) {
-          return {agency: true};
-        } else {
+        }
+        if (claims.agency) {
           return {
-            admin: false,
-            agency: false,
+            agency: true,
+            agencyId: claims.agencyId || null,
+            agencyName: claims.agencyName || null,
           };
         }
+        return {
+          admin: false,
+          agency: false,
+        };
       })
       .catch((error) => {
         console.log(error.code, error.message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
 				"uuid": "^9.0.1"
 			},
 			"devDependencies": {
+				"@firebase/rules-unit-testing": "^4.0.1",
 				"@tailwindcss/forms": "^0.5.7",
 				"@types/react": "^19.2.15",
 				"@types/react-dom": "^19.2.3",
@@ -1121,6 +1122,19 @@
 			"resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.0.tgz",
 			"integrity": "sha512-vI3bqLoF14L/GchtgayMiFpZJF+Ao3uR8WCde0XpYNkSokDpAKca2DxvcfeZv7lZUqkUwQPL2wD83d3vQ4vvrg==",
 			"license": "Apache-2.0"
+		},
+		"node_modules/@firebase/rules-unit-testing": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-4.0.1.tgz",
+			"integrity": "sha512-Vu8iMLP+dO9hCAqUCitWZQdORyM6CxucilRZtleeTZd5bejZmyOiaBPwYm3NOYG6025ac99CEeA+ETmJRxa9zg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"firebase": "^11.0.0"
+			}
 		},
 		"node_modules/@firebase/storage": {
 			"version": "0.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
 				"uuid": "^9.0.1"
 			},
 			"devDependencies": {
-				"@firebase/rules-unit-testing": "^4.0.1",
+				"@firebase/rules-unit-testing": "^5.0.1",
 				"@tailwindcss/forms": "^0.5.7",
 				"@types/react": "^19.2.15",
 				"@types/react-dom": "^19.2.3",
@@ -1124,16 +1124,16 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@firebase/rules-unit-testing": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-4.0.1.tgz",
-			"integrity": "sha512-Vu8iMLP+dO9hCAqUCitWZQdORyM6CxucilRZtleeTZd5bejZmyOiaBPwYm3NOYG6025ac99CEeA+ETmJRxa9zg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-5.0.1.tgz",
+			"integrity": "sha512-EvbxUvgoY2cG7vgtdhKc7gjalKzeO3AWr2NiUuyEEmcXaSaOJanV3hXLj3Viigs+Y/jFYQmtVPpSoiwUs/ZlPg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=20.0.0"
 			},
 			"peerDependencies": {
-				"firebase": "^11.0.0"
+				"firebase": "^12.0.0"
 			}
 		},
 		"node_modules/@firebase/storage": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
 		"dev:turbo": "npm run dev",
 		"dev:live": "sh -c 'unset FIRESTORE_EMULATOR_HOST FIREBASE_AUTH_EMULATOR_HOST FIREBASE_STORAGE_EMULATOR_HOST FIREBASE_DATABASE_EMULATOR_HOST FIREBASE_FUNCTIONS_EMULATOR_HOST; export NEXT_PUBLIC_USE_EMULATORS=false; exec next dev --webpack'",
 		"seed:emulator": "node scripts/seed-emulator-from-prod.js",
+		"backfill:agency-id": "node scripts/backfill-report-agency-id.js",
+		"verify:agency-rules": "firebase emulators:exec --only firestore,auth \"node scripts/verify-agency-firestore-rules.js\"",
 		"build": "next build --webpack",
 		"start": "next start",
 		"lint": "next lint",
@@ -48,6 +50,7 @@
 		"uuid": "^9.0.1"
 	},
 	"devDependencies": {
+		"@firebase/rules-unit-testing": "^4.0.1",
 		"@tailwindcss/forms": "^0.5.7",
 		"@types/react": "^19.2.15",
 		"@types/react-dom": "^19.2.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"uuid": "^9.0.1"
 	},
 	"devDependencies": {
-		"@firebase/rules-unit-testing": "^4.0.1",
+		"@firebase/rules-unit-testing": "^5.0.1",
 		"@tailwindcss/forms": "^0.5.7",
 		"@types/react": "^19.2.15",
 		"@types/react-dom": "^19.2.3",

--- a/scripts/backfill-report-agency-id.js
+++ b/scripts/backfill-report-agency-id.js
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+/**
+ * Backfill `agencyId` on existing report documents from agency display name.
+ *
+ * Prerequisites:
+ * - Service account JSON at repo root (misinfo-*-firebase-adminsdk*.json, gitignored)
+ *   or GOOGLE_APPLICATION_CREDENTIALS / --service-account=path
+ *
+ * Usage:
+ *   node scripts/backfill-report-agency-id.js --dry-run
+ *   node scripts/backfill-report-agency-id.js
+ *   node scripts/backfill-report-agency-id.js --limit=500
+ *   node scripts/backfill-report-agency-id.js --emulator-host=127.0.0.1:8080
+ */
+
+const admin = require('firebase-admin')
+const { FieldPath } = require('firebase-admin/firestore')
+const fs = require('fs')
+const path = require('path')
+
+const PROJECT_ID = 'misinfo-5d004'
+const PAGE_SIZE = 400
+
+/**
+ * @typedef {Object} CliOptions
+ * @property {boolean} dryRun
+ * @property {number} limit
+ * @property {string | null} emulatorHost
+ * @property {string | null} serviceAccountPath
+ */
+
+/**
+ * @returns {CliOptions}
+ */
+function parseArgs() {
+	const argv = process.argv.slice(2)
+	/** @type {CliOptions} */
+	const opts = {
+		dryRun: false,
+		limit: 0,
+		emulatorHost: null,
+		serviceAccountPath: null,
+	}
+
+	for (const arg of argv) {
+		if (arg === '--dry-run') {
+			opts.dryRun = true
+		} else if (arg.startsWith('--limit=')) {
+			const n = Number.parseInt(arg.slice('--limit='.length), 10)
+			if (!Number.isFinite(n) || n < 0) {
+				throw new Error('--limit must be a non-negative integer (0 = no limit)')
+			}
+			opts.limit = n
+		} else if (arg.startsWith('--emulator-host=')) {
+			opts.emulatorHost = arg.slice('--emulator-host='.length)
+		} else if (arg.startsWith('--service-account=')) {
+			opts.serviceAccountPath = arg.slice('--service-account='.length)
+		} else if (arg === '--help' || arg === '-h') {
+			printHelp()
+			process.exit(0)
+		} else {
+			throw new Error(`Unknown argument: ${arg}`)
+		}
+	}
+
+	return opts
+}
+
+function printHelp() {
+	console.log(`
+Backfill reports.agencyId from agency name → id map.
+
+  --dry-run                 Log changes without writing
+  --limit=N                 Process at most N reports missing agencyId (0 = all)
+  --emulator-host=HOST:PORT Use Firestore emulator
+  --service-account=PATH    Path to service account JSON
+`)
+}
+
+/**
+ * @param {CliOptions} opts
+ */
+function initAdmin(opts) {
+	if (opts.emulatorHost) {
+		process.env.FIRESTORE_EMULATOR_HOST = opts.emulatorHost
+	}
+
+	const candidates = []
+	if (opts.serviceAccountPath) {
+		candidates.push(opts.serviceAccountPath)
+	}
+	if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+		candidates.push(process.env.GOOGLE_APPLICATION_CREDENTIALS)
+	}
+	const root = path.resolve(__dirname, '..')
+	for (const file of fs.readdirSync(root)) {
+		if (/misinfo-.*firebase-adminsdk.*\.json$/i.test(file)) {
+			candidates.push(path.join(root, file))
+		}
+	}
+
+	const saPath = candidates.find((p) => p && fs.existsSync(p))
+	if (!saPath && !opts.emulatorHost) {
+		throw new Error(
+			'No service account found. Pass --service-account= or set GOOGLE_APPLICATION_CREDENTIALS.',
+		)
+	}
+
+	if (saPath) {
+		const sa = require(saPath)
+		admin.initializeApp({
+			credential: admin.credential.cert(sa),
+			projectId: sa.project_id || PROJECT_ID,
+		})
+	} else {
+		admin.initializeApp({ projectId: PROJECT_ID })
+	}
+}
+
+/**
+ * @param {FirebaseFirestore.Firestore} db
+ * @returns {Promise<Map<string, string>>}
+ */
+async function buildNameToIdMap(db) {
+	const snap = await db.collection('agency').get()
+	/** @type {Map<string, string>} */
+	const map = new Map()
+	snap.docs.forEach((docSnap) => {
+		const name = String(docSnap.data()?.name || '').trim()
+		if (!name) return
+		map.set(name, docSnap.id)
+		map.set(name.toLowerCase(), docSnap.id)
+	})
+	return map
+}
+
+/**
+ * @param {CliOptions} opts
+ */
+async function run(opts) {
+	initAdmin(opts)
+	const db = admin.firestore()
+	const nameToId = await buildNameToIdMap(db)
+	console.log(`Loaded ${nameToId.size / 2} agencies (name→id map).`)
+
+	let scanned = 0
+	let updated = 0
+	let alreadyHad = 0
+	let unmatched = 0
+	/** @type {string[]} */
+	const unmatchedNames = []
+	let lastDoc = null
+
+	// eslint-disable-next-line no-constant-condition
+	while (true) {
+		let q = db.collection('reports').orderBy(FieldPath.documentId()).limit(PAGE_SIZE)
+		if (lastDoc) {
+			q = q.startAfter(lastDoc)
+		}
+		const snap = await q.get()
+		if (snap.empty) break
+
+		const batch = db.batch()
+		let batchWrites = 0
+
+		for (const docSnap of snap.docs) {
+			if (opts.limit > 0 && scanned >= opts.limit) break
+			scanned += 1
+			const data = docSnap.data() || {}
+			const existingId =
+				typeof data.agencyId === 'string' ? data.agencyId.trim() : ''
+			if (existingId) {
+				alreadyHad += 1
+				continue
+			}
+
+			const agencyName =
+				typeof data.agency === 'string' ? data.agency.trim() : ''
+			const resolved =
+				(agencyName && nameToId.get(agencyName)) ||
+				(agencyName && nameToId.get(agencyName.toLowerCase())) ||
+				null
+
+			if (!resolved) {
+				unmatched += 1
+				if (agencyName && !unmatchedNames.includes(agencyName)) {
+					unmatchedNames.push(agencyName)
+				}
+				continue
+			}
+
+			if (opts.dryRun) {
+				console.log(`[dry-run] ${docSnap.id}: agency="${agencyName}" → ${resolved}`)
+			} else {
+				batch.update(docSnap.ref, { agencyId: resolved })
+				batchWrites += 1
+			}
+			updated += 1
+		}
+
+		if (!opts.dryRun && batchWrites > 0) {
+			await batch.commit()
+		}
+
+		lastDoc = snap.docs[snap.docs.length - 1]
+		if (snap.size < PAGE_SIZE) break
+		if (opts.limit > 0 && scanned >= opts.limit) break
+	}
+
+	console.log(
+		JSON.stringify(
+			{
+				dryRun: opts.dryRun,
+				scanned,
+				updated,
+				alreadyHad,
+				unmatched,
+				unmatchedNames,
+			},
+			null,
+			2,
+		),
+	)
+}
+
+try {
+	run(parseArgs()).catch((err) => {
+		console.error(err)
+		process.exit(1)
+	})
+} catch (err) {
+	console.error(err.message || err)
+	process.exit(1)
+}

--- a/scripts/verify-agency-firestore-rules.js
+++ b/scripts/verify-agency-firestore-rules.js
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * Emulator checks for agency-scoped Firestore rules.
+ *
+ * Prerequisites:
+ *   firebase emulators:start --only firestore,auth
+ *   (or run via: firebase emulators:exec --only firestore,auth "node scripts/verify-agency-firestore-rules.js")
+ *
+ * Uses the Firestore Rules unit-testing pattern against the emulator.
+ * Install once if needed: npm i -D @firebase/rules-unit-testing
+ */
+
+const fs = require('fs')
+const path = require('path')
+const {
+	assertFails,
+	assertSucceeds,
+	initializeTestEnvironment,
+} = require('@firebase/rules-unit-testing')
+const { doc, getDoc, setDoc, collection, getDocs, query, where } = require('firebase/firestore')
+
+const PROJECT_ID = 'misinfo-rules-test'
+const RULES_PATH = path.resolve(__dirname, '../firestore.rules')
+
+async function seed(testEnv) {
+	await testEnv.withSecurityRulesDisabled(async (context) => {
+		const db = context.firestore()
+		await setDoc(doc(db, 'agency', 'agency-a'), {
+			name: 'Agency A',
+			agencyUsers: ['a@example.com'],
+		})
+		await setDoc(doc(db, 'agency', 'agency-b'), {
+			name: 'Agency B',
+			agencyUsers: ['b@example.com'],
+		})
+		await setDoc(doc(db, 'reports', 'report-a'), {
+			agency: 'Agency A',
+			agencyId: 'agency-a',
+			userID: 'user-public',
+			experimentId: '2026-main',
+			archived: false,
+			title: 'A report',
+		})
+		await setDoc(doc(db, 'reports', 'report-b'), {
+			agency: 'Agency B',
+			agencyId: 'agency-b',
+			userID: 'other-user',
+			experimentId: '2026-main',
+			archived: false,
+			title: 'B report',
+		})
+		await setDoc(doc(db, 'tags', 'agency-a'), {
+			Topic: { list: ['Voting'], active: ['Voting'], labels: {} },
+		})
+	})
+}
+
+async function run() {
+	const testEnv = await initializeTestEnvironment({
+		projectId: PROJECT_ID,
+		firestore: {
+			rules: fs.readFileSync(RULES_PATH, 'utf8'),
+			host: '127.0.0.1',
+			port: 8080,
+		},
+	})
+
+	try {
+		await seed(testEnv)
+
+		const agencyA = testEnv.authenticatedContext('uid-a', {
+			agency: true,
+			agencyId: 'agency-a',
+			agencyName: 'Agency A',
+		})
+		const agencyB = testEnv.authenticatedContext('uid-b', {
+			agency: true,
+			agencyId: 'agency-b',
+			agencyName: 'Agency B',
+		})
+		const admin = testEnv.authenticatedContext('uid-admin', { admin: true })
+		const publicUser = testEnv.authenticatedContext('user-public', {})
+
+		const dbA = agencyA.firestore()
+		const dbB = agencyB.firestore()
+		const dbAdmin = admin.firestore()
+		const dbPublic = publicUser.firestore()
+
+		console.log('1. Agency A reads own report…')
+		await assertSucceeds(getDoc(doc(dbA, 'reports', 'report-a')))
+
+		console.log('2. Agency A denied other agency report…')
+		await assertFails(getDoc(doc(dbA, 'reports', 'report-b')))
+
+		console.log('3. Admin reads all reports…')
+		await assertSucceeds(getDoc(doc(dbAdmin, 'reports', 'report-a')))
+		await assertSucceeds(getDoc(doc(dbAdmin, 'reports', 'report-b')))
+
+		console.log('4. Public submitter reads own report…')
+		await assertSucceeds(getDoc(doc(dbPublic, 'reports', 'report-a')))
+
+		console.log('5. Agency A creates report for own agencyId…')
+		await assertSucceeds(
+			setDoc(doc(dbA, 'reports', 'report-a-new'), {
+				agency: 'Agency A',
+				agencyId: 'agency-a',
+				userID: 'uid-a',
+				experimentId: '2026-main',
+				archived: false,
+				title: 'New A',
+			}),
+		)
+
+		console.log('6. Agency A denied create for agency B…')
+		await assertFails(
+			setDoc(doc(dbA, 'reports', 'report-cross'), {
+				agency: 'Agency B',
+				agencyId: 'agency-b',
+				userID: 'uid-a',
+				experimentId: '2026-main',
+				archived: false,
+				title: 'Cross',
+			}),
+		)
+
+		console.log('7. Agency A deletes own report…')
+		await assertSucceeds(
+			setDoc(doc(dbA, 'reports', 'report-a-del'), {
+				agency: 'Agency A',
+				agencyId: 'agency-a',
+				userID: 'uid-a',
+				experimentId: '2026-main',
+				archived: false,
+				title: 'Del',
+			}),
+		)
+		const { deleteDoc } = require('firebase/firestore')
+		await assertSucceeds(deleteDoc(doc(dbA, 'reports', 'report-a-del')))
+
+		console.log('8. Agency A denied delete on B report…')
+		await assertFails(deleteDoc(doc(dbA, 'reports', 'report-b')))
+
+		console.log('9. Agency A cannot list agency B doc…')
+		await assertFails(getDoc(doc(dbA, 'agency', 'agency-b')))
+
+		console.log('10. Public can list agencies (picker)…')
+		await assertSucceeds(getDocs(collection(dbPublic, 'agency')))
+
+		console.log('11. Public can read tags for picker…')
+		await assertSucceeds(getDoc(doc(dbPublic, 'tags', 'agency-a')))
+
+		console.log('12. Agency scoped list query by agencyId…')
+		await assertSucceeds(
+			getDocs(
+				query(
+					collection(dbA, 'reports'),
+					where('agencyId', '==', 'agency-a'),
+				),
+			),
+		)
+
+		console.log('\nAll agency Firestore rules checks passed.')
+	} finally {
+		await testEnv.cleanup()
+	}
+}
+
+run().catch((err) => {
+	console.error('\nAgency rules verification failed:')
+	console.error(err)
+	process.exit(1)
+})

--- a/utils/reports-queries.js
+++ b/utils/reports-queries.js
@@ -55,7 +55,8 @@ export function getActiveExperimentId(config) {
 
 /**
  * @typedef {Object} ActiveReportsQueryOptions
- * @property {string} [agency]
+ * @property {string} [agency] Display-name filter (legacy / transition)
+ * @property {string} [agencyId] Stable agency doc id filter (preferred for scoped queries)
  * @property {string} [topic]
  * @property {import('firebase/firestore').Timestamp} [dateFrom]
  * @property {import('firebase/firestore').Timestamp} [dateTo]
@@ -70,12 +71,16 @@ export function getActiveExperimentId(config) {
 /**
  * Builds a Firestore query for operational report reads.
  *
+ * Prefer `agencyId` for agency-scoped queries (matches security rules).
+ * `agency` (display name) remains for transitional/legacy use only.
+ *
  * @param {ActiveReportsQueryOptions} [options]
  * @returns {import('firebase/firestore').Query}
  */
 export function buildActiveReportsQuery(options = {}) {
 	const {
 		agency,
+		agencyId,
 		topic,
 		dateFrom,
 		dateTo,
@@ -102,7 +107,9 @@ export function buildActiveReportsQuery(options = {}) {
 		constraints.push(where('experimentId', '==', expId))
 	}
 
-	if (agency) {
+	if (agencyId) {
+		constraints.push(where('agencyId', '==', agencyId))
+	} else if (agency) {
 		constraints.push(where('agency', '==', agency))
 	}
 
@@ -123,6 +130,25 @@ export function buildActiveReportsQuery(options = {}) {
 	}
 
 	return query(reportsRef, ...constraints)
+}
+
+/**
+ * Agency identity fields for new report documents.
+ * Keep display `agency` for UI; `agencyId` for rules and scoped queries.
+ *
+ * @param {{ agencyName?: string, agencyId?: string }} opts
+ * @returns {{ agency: string, agencyId: string }}
+ */
+export function newReportAgencyFields({ agencyName, agencyId }) {
+	const name = typeof agencyName === 'string' ? agencyName.trim() : ''
+	const id = typeof agencyId === 'string' ? agencyId.trim() : ''
+	if (!id) {
+		throw new Error('agencyId is required when creating a report')
+	}
+	return {
+		agency: name,
+		agencyId: id,
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary
- Enforce agency isolation in Firestore by stamping `agencyId` on Auth claims and report docs, then scoping rules/queries by that ID (not display name).
- Remove the signed-in catch-all rules; add explicit collection rules so agency users cannot read/write another agency’s reports (admins unchanged).
- Add claim/report backfill tooling, `agencyId` indexes, and emulator rules verification for a safe prod rollout.

## Test plan
- [ ] Create agency + public reports → each has `agency` **and** `agencyId`
- [ ] Assign/reassign Agency role → token has `agencyId`/`agencyName` (re-login or refresh)
- [ ] Dry-run then apply report backfill: `node scripts/backfill-report-agency-id.js --dry-run`
- [ ] Admin Settings → Dry-run / Backfill agency claims
- [ ] Deploy indexes; wait until ready; **then** deploy rules (not before backfill)
- [ ] `npm run verify:agency-rules`
- [ ] Smoke: two agency logins — each sees only own reports; cross-agency `get` denied; admin still sees all