### PR TITLE
Feat/color changes

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,6 +17,8 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Enable auto-merge (squash)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/components/analytics/ComparisonGraphMenu.jsx
+++ b/components/analytics/ComparisonGraphMenu.jsx
@@ -34,6 +34,7 @@ import {
 import { Tooltip } from "react-tooltip";
 import Select from 'react-select';
 import makeAnimated from 'react-select/animated';
+import LoadingSpinner from '../ui/LoadingSpinner'
 
 /**
  * ComparisonGraphMenu Component
@@ -212,12 +213,12 @@ const ComparisonGraphMenu = ({dateRange, setDateRange,
           }
           
 
-          {/* Displays loading svg if the graph is being updated. */}	
+          {/* Displays loading spinner while the graph is being updated. */}
           {!loaded &&
-             <svg aria-hidden="true" className="ml-2 w-8 h-8 mr-2 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">	
-              <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor" />	
-              <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentColor" />	
-            </svg>}
+            <div className="ml-2 mr-2 flex items-center" role="status" aria-label="Loading graph">
+              <LoadingSpinner className="h-8 w-8 text-[#2E3B4E]" />
+            </div>
+          }
             </div>
             
             <div className="flex items-center">

--- a/components/analytics/ComparisonGraphMenu.jsx
+++ b/components/analytics/ComparisonGraphMenu.jsx
@@ -11,7 +11,7 @@
  * Integrates with:
  * - react-date-range for date selection
  * - react-select for topic selection
- * - react-icons and react-tooltip for UI/UX
+ * - @material-tailwind/react for actions, alerts, and loading
  *
  * @author Misinformation Dashboard Team
  * @version 1.0.0
@@ -28,13 +28,16 @@ import {
   IoMdCalendar,
   IoMdRefresh,
   IoMdRemove,
-  IoIosAlert,
   IoIosTrash
 } from "react-icons/io";
-import { Tooltip } from "react-tooltip";
+import {
+  Alert,
+  IconButton,
+  Spinner,
+  Tooltip,
+} from '@material-tailwind/react'
 import Select from 'react-select';
 import makeAnimated from 'react-select/animated';
-import LoadingSpinner from '../ui/LoadingSpinner'
 
 /**
  * ComparisonGraphMenu Component
@@ -66,10 +69,6 @@ const ComparisonGraphMenu = ({dateRange, setDateRange,
                             updateGraph, setUpdateGraph, loaded, setLoaded}) => {
   const [showCalendar, setShowCalendar] = useState(0)
 
-  // Styling for graph setting buttons.
-  const basicStyle = "flex p-2 my-6 mx-2 text-gray-500 hover:bg-blue-100 rounded-lg"
-  const errorStyle = "flex p-2 my-6 mx-2 text-gray-500 hover:bg-red-100 rounded-lg bg-red-100 border-2 border-rose-600"                           
-  
   // Border style used for the topic select dropdown for error handling.
   const borderStyle = {
     control: (base) => ({
@@ -128,11 +127,9 @@ const ComparisonGraphMenu = ({dateRange, setDateRange,
    */
   const handleDateSelection = (item) =>  {
     if (item.selection.endDate !== item.selection.startDate) {
-        console.log(item)
         const daysSelected = ((item.selection.endDate - item.selection.startDate)/(1000*60*60*24)) + 1 	
         setDateRange([item.selection])	
         setDateError(!(daysSelected > 2 && daysSelected < 31))	
-        console.log(dateError)	
         if (daysSelected > 2 && daysSelected < 31) {	
           setUpdateGraph(true)   	
         }	
@@ -164,33 +161,23 @@ const ComparisonGraphMenu = ({dateRange, setDateRange,
 
   return (
   <>
-    <div className="relative flex justify-stretch lg:justify-between flex-wrap">
-      <div className="flex justify-between items-center">
+    <div className="relative flex justify-stretch lg:justify-between flex-wrap gap-2">
+      <div className="flex flex-wrap items-center gap-1">
         {/* Calendar allows user to change date range. */}
-        {showCalendar == 0 ? 
-          <button
-            onClick={() => handleSelect()}
-            data-tip="Select Dates"
-            className={`${ dateError ? errorStyle : basicStyle } tooltip-select-dates`}
-            >
-            <IoMdCalendar size={25}/>
-            <Tooltip anchorSelect=".tooltip-select-dates" place="top" delayShow={500}>Select Dates</Tooltip>
-          </button>
-          :
-          <button
-            onClick={() => handleSelect()}
-            data-tip="Close calendar"
-              className={`${ dateError ? errorStyle : basicStyle } text-stone-400 bg-blue-100 tooltip-close-calendar`}
-            >
-            <IoMdRemove size={25} />
-            <Tooltip anchorSelect=".tooltip-close-calendar" place="top" delayShow={500}>Close Calendar</Tooltip>
-          </button> 
-        }
+        <Tooltip content={showCalendar == 0 ? 'Select Dates' : 'Close Calendar'}>
+          <IconButton
+            variant="text"
+            color={dateError ? 'red' : 'blue-gray'}
+            className={dateError ? 'bg-red-50' : showCalendar == 1 ? 'bg-blue-50' : ''}
+            onClick={handleSelect}
+            aria-label={showCalendar == 0 ? 'Select Dates' : 'Close Calendar'}
+          >
+            {showCalendar == 0 ? <IoMdCalendar size={22} /> : <IoMdRemove size={22} />}
+          </IconButton>
+        </Tooltip>
 
-        
-          
           {/* Allows user to change the selected topics. */}
-          <div className={topicError ? errorOutline : null}>
+          <div className={`min-w-[12rem] flex-1 ${topicError ? errorOutline : ''}`}>
             <Select options={listTopicChoices} components={animatedComponents}
                 isMulti 
                 error={topicError}
@@ -203,52 +190,52 @@ const ComparisonGraphMenu = ({dateRange, setDateRange,
         
           {/* Allows user to refresh graph when new topics or date range have been selected. */}
           {loaded &&
-            <button
-              onClick={() => handleGraphUpdate()}
-              data-tip="Refresh Graph"
-              className={`${ basicStyle } tooltip-refresh-graph`}>	
-              <IoMdRefresh size={25} />
-              <Tooltip anchorSelect=".tooltip-refresh-graph" place="top" delayShow={500}>Refresh Graph</Tooltip>
-            </button>
+            <Tooltip content="Refresh Graph">
+              <IconButton
+                variant="text"
+                color="blue-gray"
+                onClick={handleGraphUpdate}
+                aria-label="Refresh Graph"
+              >
+                <IoMdRefresh size={22} />
+              </IconButton>
+            </Tooltip>
           }
-          
 
           {/* Displays loading spinner while the graph is being updated. */}
           {!loaded &&
-            <div className="ml-2 mr-2 flex items-center" role="status" aria-label="Loading graph">
-              <LoadingSpinner className="h-8 w-8 text-[#2E3B4E]" />
+            <div className="mx-2 flex items-center" role="status" aria-label="Loading graph">
+              <Spinner className="h-6 w-6" color="blue" />
             </div>
           }
             </div>
             
-            <div className="flex items-center">
+            <div className="flex flex-wrap items-center gap-2 flex-1 justify-end">
             {/*Displays notification when user needs to refresh graph once the topic or date selection has been modified. */}
             {updateGraph && loaded && !(topicError || dateError) && !showCalendar &&
-              <div className="flex flex-wrap text-black bg-green-200 rounded p-3 ml-2 border-2 border-green-600">
-                <IoIosAlert size={25} />
-                <h1 className="pl-3">Refresh the graph to see the report data for the most recent changes.</h1>
-
-              </div>
+              <Alert color="green" className="py-2 px-3 text-sm max-w-xl">
+                Refresh the graph to see the report data for the most recent changes.
+              </Alert>
             }
 
-            {/* Displays error when there are not three selected topics, or the date range is not valid. */}
+            {/* Displays error when topic or date selection is invalid. */}
             {(topicError || dateError) && !showCalendar && 
-              <div className="flex flex-cols flex-wrap text-black bg-red-200 rounded p-3 ml-2 border-2 border-rose-600">
-                <IoIosAlert size={25} />
-                <div className="inline-block">
-                    {topicError && <h1 className="pl-3">You must select at least one topic to compare.</h1>}
-                    {dateError && <h1 className="pl-3">You must select a date range of at least three days and no more than three weeks.</h1>}
-                </div>
-              </div>
+              <Alert color="red" className="py-2 px-3 text-sm max-w-xl">
+                {topicError && <div>You must select at least one topic to compare.</div>}
+                {dateError && <div>You must select a date range of at least three days and no more than three weeks.</div>}
+              </Alert>
             }
           
-          <button
-            onClick={() => handleReset()}
-            data-tip="Clear graph"
-            className={`${ basicStyle } justify-between ml-auto lg:justify-self-end pr-2 tooltip-clear-graph`}>
-            <IoIosTrash size={25}/>
-            <Tooltip anchorSelect=".tooltip-clear-graph" place="top" delayShow={500}>Clear Graph</Tooltip>
-          </button>
+          <Tooltip content="Clear Graph">
+            <IconButton
+              variant="text"
+              color="blue-gray"
+              onClick={handleReset}
+              aria-label="Clear Graph"
+            >
+              <IoIosTrash size={22} />
+            </IconButton>
+          </Tooltip>
 
       </div>
       

--- a/components/analytics/ComparisonGraphPlotted.jsx
+++ b/components/analytics/ComparisonGraphPlotted.jsx
@@ -43,6 +43,7 @@ import {
   getActiveExperimentId,
 } from '../../utils/reports-queries'
 import ComparisonGraphMenu from './ComparisonGraphMenu'
+import { Spinner, Typography } from '@material-tailwind/react'
 
 import _ from "lodash";
 
@@ -160,8 +161,45 @@ const ComparisonGraphPlotted = ({dateRange, setDateRange, selectedTopics, setSel
   }
 
   /**
+   * bucketCountsByDay - Counts reports into per-day buckets using day-boundary Timestamps.
+   * Day i is [dayBounds[i], dayBounds[i + 1]).
+   * @param {import('firebase/firestore').QueryDocumentSnapshot[]} docs
+   * @param {import('firebase/firestore').Timestamp[]} dayBounds
+   * @returns {number[]}
+   */
+  const bucketCountsByDay = (docs, dayBounds) => {
+    const numDays = dayBounds.length - 1
+    const counts = new Array(numDays).fill(0)
+    const boundMs = dayBounds.map((t) => t.toMillis())
+
+    for (const reportDoc of docs) {
+      const created = reportDoc.data()?.createdDate
+      if (!created) continue
+      let ms
+      if (typeof created.toMillis === 'function') {
+        ms = created.toMillis()
+      } else if (typeof created.seconds === 'number') {
+        ms =
+          created.seconds * 1000 +
+          Math.floor((created.nanoseconds || 0) / 1e6)
+      } else {
+        ms = Number(created)
+      }
+      if (!Number.isFinite(ms)) continue
+
+      for (let i = 0; i < numDays; i++) {
+        if (ms >= boundMs[i] && ms < boundMs[i + 1]) {
+          counts[i] += 1
+          break
+        }
+      }
+    }
+    return counts
+  }
+
+  /**
  * getDailyTopicReports - Fetches and aggregates report counts for each topic and date in the range.
- * Updates state with the results for graph rendering.
+ * One range query per topic (parallel), then buckets counts by day client-side.
  */
   const getDailyTopicReports = async() => {
     // Agency-scoped rules reject unscoped list queries — never fetch until agencyId is known.
@@ -169,9 +207,11 @@ const ComparisonGraphPlotted = ({dateRange, setDateRange, selectedTopics, setSel
 
     const days = Math.ceil((dateRange[0].endDate.getTime()- dateRange[0].startDate.getTime()) / 86400000)
     const array = getDates(days)
+    const dayBounds = array[0]
+    const emptyCounts = () => new Array(Math.max(0, dayBounds.length - 1)).fill(0)
     
     // Stores dates in format used to query the reports. 
-    setDates(array[0])
+    setDates(dayBounds)
 
     // Stores date labels used for the x-axis on the comparison chart
     setDateLabels (array[1])
@@ -179,34 +219,28 @@ const ComparisonGraphPlotted = ({dateRange, setDateRange, selectedTopics, setSel
     const experimentConfig = await fetchExperimentConfig()
     const activeExperimentId = getActiveExperimentId(experimentConfig)
     const agencyIdFilter = privilege === 'Agency' ? agencyId : undefined
+    const rangeFrom = dayBounds[0]
+    const rangeTo = dayBounds[dayBounds.length - 1]
 
-    // Stores the number of times that the topic was reported for each day within timeline
-    const topicArray = []
-    
-    // Maintain daily count of reports for top three topics within given timeline
-    for (let topic = 0; topic < selectedTopics.length; topic++) {
-      const numReports = []
-      for (let index = 0; index < array[0].length - 1; index++) {
-
-        const queryDaily = buildActiveReportsQuery({
-          topic: selectedTopics[topic].value,
-          dateFrom: array[0][index],
-          dateTo: array[0][index + 1],
-          agencyId: agencyIdFilter,
-          activeExperimentId,
-        })
+    // One query per topic over the full range; parallelize topics.
+    const topicArray = await Promise.all(
+      selectedTopics.map(async (topic) => {
         try {
-          const dailyReports = await getDocs(queryDaily)
-          numReports.push(dailyReports.size)
+          const rangeQuery = buildActiveReportsQuery({
+            topic: topic.value,
+            dateFrom: rangeFrom,
+            dateTo: rangeTo,
+            agencyId: agencyIdFilter,
+            activeExperimentId,
+          })
+          const snapshot = await getDocs(rangeQuery)
+          return bucketCountsByDay(snapshot.docs, dayBounds)
         } catch (error) {
-          console.error('Comparison graph daily query failed:', error)
-          numReports.push(0)
+          console.error('Comparison graph range query failed:', error)
+          return emptyCounts()
         }
-      }
-
-      // Keeps track of each topic and the amount of times it was reported each day for the specified timeline
-      topicArray.push(numReports)
-    }
+      }),
+    )
     setData(topicArray)
   }
   
@@ -435,7 +469,7 @@ const ComparisonGraphPlotted = ({dateRange, setDateRange, selectedTopics, setSel
   return (
     <div>
           {/* Once user selects the topics and date range, graph of topic reports will be plotted. */}
-          <div className="bg-white rounded-md mt-6 py-5">
+          <div className="bg-white rounded-md mt-6 py-5 px-3">
           <ComparisonGraphMenu dateRange={dateRange} setDateRange={setDateRange} 
               selectedTopics={selectedTopics} setSelectedTopics={setSelectedTopics}
               listTopicChoices={topicList} tab={tab} setTab={setTab}
@@ -447,15 +481,23 @@ const ComparisonGraphPlotted = ({dateRange, setDateRange, selectedTopics, setSel
 		
             {loaded ?	
             <div className="m-auto">	
-              {/* Displays graph once data is collected for the topics. */}	
-              <div className="text-xl lg:text-2xl font-bold text-[#2E3B4E] pt-6 tracking-wider text-center ">Topic Reports - {formatDates()}</div>	
+              <Typography
+                variant="h5"
+                color="blue"
+                className="pt-6 tracking-wider text-center"
+              >
+                Topic Reports - {formatDates()}
+              </Typography>
               <div className="relative z-10 lg:pl-20 lg:pr-20 overflow-x-auto max-h-[340px] min-h-[220px]">
                 <Line height={280} options={options} data={graphData} />
               </div>	
             </div>	
             : (
-            <div className="flex flex-col items-center justify-center min-h-[220px] pt-6 text-[#2E3B4E]">
-              <p className="text-sm text-gray-500">Loading report data for selected topics…</p>
+            <div className="flex flex-col items-center justify-center gap-3 min-h-[220px] pt-6">
+              <Spinner className="h-8 w-8" color="blue" />
+              <Typography variant="small" className="text-gray-500">
+                Loading report data for selected topics…
+              </Typography>
             </div>
             )}	
         </div>

--- a/components/analytics/ComparisonGraphPlotted.jsx
+++ b/components/analytics/ComparisonGraphPlotted.jsx
@@ -86,9 +86,14 @@ const ComparisonGraphPlotted = ({dateRange, setDateRange, selectedTopics, setSel
   const { verifyRole, refreshCustomClaims, customClaims } = useAuth() // Auth context
   const agencyClaimsRefreshAttempted = useRef(false)
 
+  // Futuristic Robot palette (dark → light for contrast on white chart bg)
   const palette = [
-    '#2563EB', '#A855F7', '#22C55E', '#F59E0B', '#0EA5E9', '#EF4444', '#14B8A6',
-    '#F97316', '#8B5CF6', '#10B981', '#6366F1', '#EC4899', '#84CC16', '#06B6D4'
+    '#071C2C', // Trapped Darkness
+    '#103A54', // Gibraltar Sea
+    '#315D77', // Berry Blue
+    '#688390', // Blue Prince
+    '#A2AAA4', // Ginkgo Green
+    '#DBDDD5', // Pacific Fog
   ]
 
   // Keep topic colors consistent even if the selection order changes.

--- a/components/analytics/ComparisonGraphPlotted.jsx
+++ b/components/analytics/ComparisonGraphPlotted.jsx
@@ -445,7 +445,7 @@ const ComparisonGraphPlotted = ({dateRange, setDateRange, selectedTopics, setSel
 
             {/* Displays graph once data is collected for the topics. */}
 		
-            {loaded &&	
+            {loaded ?	
             <div className="m-auto">	
               {/* Displays graph once data is collected for the topics. */}	
               <div className="text-xl lg:text-2xl font-bold text-[#2E3B4E] pt-6 tracking-wider text-center ">Topic Reports - {formatDates()}</div>	
@@ -453,7 +453,11 @@ const ComparisonGraphPlotted = ({dateRange, setDateRange, selectedTopics, setSel
                 <Line height={280} options={options} data={graphData} />
               </div>	
             </div>	
-            }	
+            : (
+            <div className="flex flex-col items-center justify-center min-h-[220px] pt-6 text-[#2E3B4E]">
+              <p className="text-sm text-gray-500">Loading report data for selected topics…</p>
+            </div>
+            )}	
         </div>
     </div>
   )

--- a/components/analytics/ComparisonGraphPlotted.jsx
+++ b/components/analytics/ComparisonGraphPlotted.jsx
@@ -159,7 +159,9 @@ const ComparisonGraphPlotted = ({dateRange, setDateRange, selectedTopics, setSel
  * Updates state with the results for graph rendering.
  */
   const getDailyTopicReports = async() => {
-    // console.log("before date: " + dateRange[0].endDate.getTime())
+    // Agency-scoped rules reject unscoped list queries — never fetch until agencyId is known.
+    if (privilege === 'Agency' && !agencyId) return
+
     const days = Math.ceil((dateRange[0].endDate.getTime()- dateRange[0].startDate.getTime()) / 86400000)
     const array = getDates(days)
     
@@ -188,17 +190,12 @@ const ComparisonGraphPlotted = ({dateRange, setDateRange, selectedTopics, setSel
           agencyId: agencyIdFilter,
           activeExperimentId,
         })
-        const dailyReports = await getDocs(queryDaily);
-
-
         try {
+          const dailyReports = await getDocs(queryDaily)
           numReports.push(dailyReports.size)
-          // console.log(selectedTopics[topic].value)
-          // console.log("day:" + array[0][index])
-          // console.log(dailyReports.size)
-        }
-        catch (error) {
-          console.log(error)
+        } catch (error) {
+          console.error('Comparison graph daily query failed:', error)
+          numReports.push(0)
         }
       }
 
@@ -323,12 +320,13 @@ const ComparisonGraphPlotted = ({dateRange, setDateRange, selectedTopics, setSel
     }	
   }, [graphData])
 
-  // On page load, populates graph with the given topics and date range.
-  useEffect (()=> {
-    if (loaded == false) {
-      getDailyTopicReports()
-    }
-  }, [loaded]);
+  // Fetch only after role resolution so agency queries include agencyId (matches rules).
+  useEffect(() => {
+    if (loaded !== false) return
+    if (!checkRole) return
+    if (privilege === 'Agency' && !agencyId) return
+    getDailyTopicReports()
+  }, [loaded, checkRole, privilege, agencyId]);
 
 
   // Configuration for React-ChartJS-2

--- a/components/analytics/ComparisonGraphSetup.jsx
+++ b/components/analytics/ComparisonGraphSetup.jsx
@@ -73,7 +73,15 @@ const ComparisonGraphSetup = ({privilege, agencyId}) => {
   // --- Validation state ---
   const [topicError, setTopicError] = useState(false) // Error state for topic selection
   const [dateError, setDateError] = useState(false) // Error state for date selection
-  const [dateRangeSelected, setDateRangeSelected] = useState(false) // Whether the user actively picked dates
+
+  const getDaysSelected = (range = dateRange[0]) =>
+    ((range.endDate - range.startDate) / (1000 * 60 * 60 * 24)) + 1
+
+  // Valid comparison window: 3–30 days inclusive (matches graph refresh rules).
+  const isValidDateRange = (range = dateRange[0]) => {
+    const daysSelected = getDaysSelected(range)
+    return daysSelected > 2 && daysSelected < 31
+  }
 
   /**
    * Handles the selection of a new date range.
@@ -83,11 +91,7 @@ const ComparisonGraphSetup = ({privilege, agencyId}) => {
   const handleDateSelection = (item) => {
     if (item.selection.endDate !== item.selection.startDate) {
       setDateRange([item.selection])
-      const daysSelected = ((item.selection.endDate  - item.selection.startDate)/(1000*60*60*24)) + 1
-      setDateRangeSelected(true)
-      if (daysSelected > 2 && daysSelected < 31) {
-        setDateError(false)
-      }
+      setDateError(!isValidDateRange(item.selection))
     } 
   }
 
@@ -105,8 +109,7 @@ const ComparisonGraphSetup = ({privilege, agencyId}) => {
    * Sets error state if invalid.
    */
   const handleGraphChange = () => {
-    const daysSelected = ((dateRange[0].endDate - dateRange[0].startDate)/(1000*60*60*24)) + 1
-    if (daysSelected > 2 && daysSelected < 31) {
+    if (isValidDateRange()) {
       setTab(4)
       setDateError(false)
     } else {
@@ -123,7 +126,6 @@ const ComparisonGraphSetup = ({privilege, agencyId}) => {
       setTopicError(true)
     } else  {
       setTopicError(false)
-      setDateRangeSelected(false)
       setTab(1)
     }
   }
@@ -157,6 +159,7 @@ const ComparisonGraphSetup = ({privilege, agencyId}) => {
   const animatedComponents = makeAnimated();
 
   const canProceedToDates = selectedTopics.length > 0
+  const canProceedToGraph = isValidDateRange()
 
   return (
     <div className="relative h-full lg:h-1/2">
@@ -240,7 +243,7 @@ const ComparisonGraphSetup = ({privilege, agencyId}) => {
                     </div>
                    
                 </div>
-                {dateRangeSelected &&
+                {canProceedToGraph &&
                   <Button
                     size="sm"
                     variant="outlined"

--- a/components/analytics/ComparisonGraphSetup.jsx
+++ b/components/analytics/ComparisonGraphSetup.jsx
@@ -13,6 +13,7 @@
  * Integrates with:
  * - ComparisonGraphPlotted (for rendering the comparison graph)
  * - react-date-range and react-select for UI controls
+ * - @material-tailwind/react for typography, buttons, and alerts
  * - Firebase Firestore for topic data
  *
  * @author Misinformation Dashboard Team
@@ -24,7 +25,7 @@ import { DateRange } from 'react-date-range';
 
 import 'react-date-range/dist/styles.css'; // main style file
 import 'react-date-range/dist/theme/default.css'; // theme css file
-import { startOfDay, subDays } from 'date-fns'
+import { subDays } from 'date-fns'
 import { getDoc, doc } from "firebase/firestore";
 import { db } from '../../config/firebase'
 import {
@@ -32,11 +33,13 @@ import {
   IoIosArrowBack,
 } from "react-icons/io";
 import ComparisonGraphPlotted from './ComparisonGraphPlotted'
-import { Tooltip } from "react-tooltip";
+import {
+  Alert,
+  Button,
+  Typography,
+} from '@material-tailwind/react'
 import Select from 'react-select';
 import makeAnimated from 'react-select/animated';
-import _ from "lodash";
-import globalStyles from '../../styles/globalStyles';
 import firebaseHelper from '../../firebase/FirebaseHelper'
 /**
  * ComparisonGraphSetup Component
@@ -56,8 +59,6 @@ const ComparisonGraphSetup = ({privilege, agencyId}) => {
   const [listTopicChoices, setTopicChoices] = useState([]) // List of available topics for selection
 
   // --- Date range state ---
-  const defaultStartDay = startOfDay(new Date())
-  defaultStartDay.setHours(-24 * 6, 0, 0, 0)
   const [dateRange, setDateRange] = useState([
     {
       startDate: subDays(new Date(), 7),
@@ -74,9 +75,6 @@ const ComparisonGraphSetup = ({privilege, agencyId}) => {
   const [dateError, setDateError] = useState(false) // Error state for date selection
   const [dateRangeSelected, setDateRangeSelected] = useState(false) // Whether the user actively picked dates
 
-  // --- Styling for graph setting buttons ---
-  const basicStyle = "flex p-2 my-6 mx-2 text-gray-500 hover:bg-blue-100 rounded-lg"
-
   /**
    * Handles the selection of a new date range.
    * Validates the range and updates state.
@@ -84,7 +82,6 @@ const ComparisonGraphSetup = ({privilege, agencyId}) => {
    */
   const handleDateSelection = (item) => {
     if (item.selection.endDate !== item.selection.startDate) {
-      console.log(item)
       setDateRange([item.selection])
       const daysSelected = ((item.selection.endDate  - item.selection.startDate)/(1000*60*60*24)) + 1
       setDateRangeSelected(true)
@@ -108,10 +105,8 @@ const ComparisonGraphSetup = ({privilege, agencyId}) => {
    * Sets error state if invalid.
    */
   const handleGraphChange = () => {
-    console.log("date range before plotting " + dateRange)
     const daysSelected = ((dateRange[0].endDate - dateRange[0].startDate)/(1000*60*60*24)) + 1
     if (daysSelected > 2 && daysSelected < 31) {
-      console.log(dateRange[0])
       setTab(4)
       setDateError(false)
     } else {
@@ -124,7 +119,6 @@ const ComparisonGraphSetup = ({privilege, agencyId}) => {
    * Sets error state if none selected.
    */
   const handleTopicSelection = () => {
-    console.log(selectedTopics)
     if (selectedTopics.length < 1) {
       setTopicError(true)
     } else  {
@@ -166,14 +160,24 @@ const ComparisonGraphSetup = ({privilege, agencyId}) => {
 
   return (
     <div className="relative h-full lg:h-1/2">
-      <h1 className={`${globalStyles.heading.h1.blue} text-center`}>Compare Topic Reports</h1>
+      <Typography variant="h4" color="blue" className="text-center tracking-wider">
+        Compare Topic Reports
+      </Typography>
               {/* Initial screen that appears when user selects the comparison view. Allows user to select three topics. */}
             {tab == 0 && 
-              <div className="flex items-center justify-center md:ml-12">
-              <div className="bg-white rounded-md mt-6 py-5 pl-3 pr-3 h-auto">
-                <h2 className={`${globalStyles.heading.h2.blue} text-center py-4`}>Select topics to compare. </h2>
-                <h1 className="pl-3 pb-4 text-center">Choose at least one topic to view the number of reports.</h1>
-                {topicError && <h1 className="pl-3 pb-4 text-center text-red-500">You must choose at least one topic to compare.</h1>}
+              <div className="flex items-center justify-center gap-3 md:ml-12 flex-wrap">
+              <div className="bg-white rounded-md mt-6 py-5 px-4 h-auto w-full max-w-xl">
+                <Typography variant="h5" color="blue" className="text-center py-2">
+                  Select topics to compare.
+                </Typography>
+                <Typography variant="paragraph" className="pb-4 text-center text-gray-700">
+                  Choose at least one topic to view the number of reports.
+                </Typography>
+                {topicError && (
+                  <Alert color="red" className="mb-3 py-2 text-sm">
+                    You must choose at least one topic to compare.
+                  </Alert>
+                )}
                 <Select options={listTopicChoices} components={animatedComponents}
                 isMulti 
                 onChange={item => setSelectedTopics(item)}
@@ -182,38 +186,46 @@ const ComparisonGraphSetup = ({privilege, agencyId}) => {
                 />
               </div>
               {canProceedToDates &&
-                <button
-                  onClick={() => handleTopicSelection()}
-                  className={`${basicStyle} tooltip-next`}>
-                  <span className="font-semibold pr-2">Next</span>
-                  <IoIosArrowForward size={25} />
-                  <Tooltip anchorSelect=".tooltip-next" place="top" delayShow={500}>Select dates</Tooltip>
-                </button>
+                <Button
+                  size="sm"
+                  variant="outlined"
+                  color="blue"
+                  className="flex items-center gap-2 mt-6"
+                  onClick={handleTopicSelection}
+                >
+                  Next
+                  <IoIosArrowForward size={18} />
+                </Button>
               }
             </div>
             }
             {/* Second screen that appears when user selects the comparison view. Allows user to select date range. */}
 
             {tab == 1 &&
-              <div className="flex flex-wrap lg:items-center lg:justify-center">
-                <button
+              <div className="flex flex-wrap lg:items-center lg:justify-center gap-3">
+                <Button
+                  size="sm"
+                  variant="outlined"
+                  color="blue"
+                  className="flex items-center gap-1 ml-[35%] lg:ml-0 mt-6"
                   onClick={() => setTab(0)}
-                  className={`${basicStyle} ml-[35%] lg:ml-0 tooltip-previous`}>
-                  <IoIosArrowBack size={25} />
-                  <Tooltip anchorSelect=".tooltip-previous" place="top" delayShow={500}>Previous</Tooltip>
-                </button>
-                                <div className="bg-white rounded-md mt-6 py-5 pl-3 pr-3 w-full lg:w-1/3 overflow-x-auto order-first lg:order-none">
-                  <h1 className="text-2xl font-bold text-[#2E3B4E] pt-6 tracking-wider text-center ">Select dates</h1>
-                  <h1 className="pl-3 text-center">Select a date range to collect the number of reports for the selected topics. </h1>
-                  {dateError && <h1 className="pl-3 pb-4 text-center text-red-500">You must select a date range of at least three days and no more than three weeks.</h1>}
+                >
+                  <IoIosArrowBack size={18} />
+                  Back
+                </Button>
+                                <div className="bg-white rounded-md mt-6 py-5 px-4 w-full lg:w-1/3 overflow-x-auto order-first lg:order-none">
+                  <Typography variant="h5" color="blue" className="pt-2 tracking-wider text-center">
+                    Select dates
+                  </Typography>
+                  <Typography variant="paragraph" className="text-center text-gray-700">
+                    Select a date range to collect the number of reports for the selected topics.
+                  </Typography>
+                  {dateError && (
+                    <Alert color="red" className="my-3 py-2 text-sm">
+                      You must select a date range of at least three days and no more than three weeks.
+                    </Alert>
+                  )}
                   
-                    {/* <DateRangePicker
-                    onChange={item => handleDateSelection(item)}
-                    showSelectionPreview={true}
-                    moveRangeOnFirstSelection={false}
-                    maxDate={new Date()}
-                    ranges={dateRange}
-                    direction="horizontal"/> */}
                   {/* TODO: fix resizing on mobile screen and choose one of these calendar views*/}
                     <div className="flex items-center justify-center pt-3">
                         <DateRange
@@ -229,33 +241,32 @@ const ComparisonGraphSetup = ({privilege, agencyId}) => {
                    
                 </div>
                 {dateRangeSelected &&
-                  <button
-                    onClick={() => handleGraphChange()}
-                    className={`${basicStyle} tooltip-display-graph`}>
-                    <span className="font-semibold pr-2">Next</span>
-                    <IoIosArrowForward size={25} />
-                    <Tooltip anchorSelect=".tooltip-display-graph" place="top" delayShow={500}>Display Graph</Tooltip>
-                  </button>
+                  <Button
+                    size="sm"
+                    variant="outlined"
+                    color="blue"
+                    className="flex items-center gap-2 mt-6"
+                    onClick={handleGraphChange}
+                  >
+                    Next
+                    <IoIosArrowForward size={18} />
+                  </Button>
                 }
               </div>
             }
           
         {/* Once user selects the topics and date range, graph of topic reports will be plotted. */}
         {tab == 4 && dateRange && selectedTopics && 
-          <div className="bg-white rounded-md mt-6 py-5">
-            <ComparisonGraphPlotted 
-              dateRange={dateRange} 
-              setDateRange={setDateRange} 
-              selectedTopics={selectedTopics} 
-              setSelectedTopics={setSelectedTopics}
-              topicList={listTopicChoices} 
-              tab={tab} 
-              setTab={setTab} />
-          </div>
+          <ComparisonGraphPlotted 
+            dateRange={dateRange} 
+            setDateRange={setDateRange} 
+            selectedTopics={selectedTopics} 
+            setSelectedTopics={setSelectedTopics}
+            topicList={listTopicChoices} 
+            tab={tab} 
+            setTab={setTab} />
         }
     </div>
   )
 }
 export default ComparisonGraphSetup
-
-

--- a/components/dashboard/OverviewGraph.jsx
+++ b/components/dashboard/OverviewGraph.jsx
@@ -48,9 +48,9 @@ const OverviewGraph = ({loaded, yesterdayReports, threeDayReports, sevenDayRepor
   // console.log(date)
   const options = {
     slices: {
-      0: { color: '#F6413A' },
-      1: { color: '#FFCA29' },
-      2: { color: '#2196F3'}
+      0: { color: '#071C2C' }, // Trapped Darkness — largest
+      1: { color: '#688390' }, // Blue Prince — middle
+      2: { color: '#A2AAA4' }, // Ginkgo Green — smallest
     },
     legend: {backgroundColor: 'white'},
     backgroundColor: 'none',

--- a/components/dashboard/TagGraph.jsx
+++ b/components/dashboard/TagGraph.jsx
@@ -166,35 +166,48 @@ const TagGraph = () => {
 	}
 
 	/**
+	 * Reads createdDate from a report doc as epoch ms.
+	 * @param {unknown} created
+	 * @returns {number|null}
+	 */
+	const createdDateToMs = (created) => {
+		if (!created) return null
+		if (typeof created.toMillis === 'function') return created.toMillis()
+		if (typeof created.seconds === 'number') {
+			return (
+				created.seconds * 1000 +
+				Math.floor((created.nanoseconds || 0) / 1e6)
+			)
+		}
+		const ms = Number(created)
+		return Number.isFinite(ms) ? ms : null
+	}
+
+	/**
 	 * Fetches and processes topic report data for visualization.
-	 * 
-	 * This function retrieves report data from Firestore, filters by user role
-	 * and time periods, and processes the data to identify trending topics.
-	 * It handles both agency-specific and system-wide data aggregation.
-	 * 
+	 *
+	 * One range query for the past 7 days, then buckets counts client-side into
+	 * yesterday / 3-day / 7-day windows (avoids topics × 3 sequential reads).
+	 *
 	 * @returns {Promise<void>} Resolves when all data is processed
-	 * @throws {Error} When data fetching or processing fails
 	 */
 	async function getTopicReports() {
 		setLoading(true)
 		const experimentConfig = await fetchExperimentConfig()
 		const activeExperimentId = getActiveExperimentId(experimentConfig)
-		
+
 		// Fetch topics based on user privilege
 		let tempTopics = []
 		if (privilege === 'Agency') {
-			// Retrieve agency-specific topics
 			const topicDoc = doc(db, 'tags', agencyId)
 			const topicRef = await getDoc(topicDoc)
 			tempTopics = topicRef.get('Topic')['active']
 			setTopics(tempTopics)
 		} else {
 			try {
-				// Retrieve all system-wide topics
 				const tags = await FirebaseHelper.fetchAllRecordsOfCollection('tags')
 				const allActiveTopics = tags.map((tag) => tag.Topic.active)
 				const combinedTopics = allActiveTopics.flat()
-				// Remove duplicates
 				tempTopics = [...new Set(combinedTopics)]
 				setTopics(tempTopics)
 			} catch (error) {
@@ -206,78 +219,74 @@ const TagGraph = () => {
 			setLoading(false)
 			return
 		}
-		
-		// Initialize arrays for different time periods
-		const topicsYesterday = []
-		const topicsThreeDays = []
-		const topicsSevenDays = []
 
-		// Process each topic for different time periods
-		for (let index = 0; index < tempTopics.length; index++) {
-			const agencyIdFilter =
-				privilege === 'Agency' ? agencyId : undefined
+		const activeTopicSet = new Set(tempTopics)
+		const agencyIdFilter = privilege === 'Agency' ? agencyId : undefined
+		const rangeFrom = getStartOfDay(7)
+		const rangeTo = getEndOfDay()
+		const yesterdayFromMs = getStartOfDay(1).toMillis()
+		const threeDaysFromMs = getStartOfDay(3).toMillis()
+		const sevenDaysFromMs = rangeFrom.toMillis()
+		const rangeToMs = rangeTo.toMillis()
 
-			const queryYesterday = buildActiveReportsQuery({
-				topic: tempTopics[index],
-				dateFrom: getStartOfDay(1),
-				dateTo: getEndOfDay(),
-				agencyId: agencyIdFilter,
-				activeExperimentId,
-			})
-			const dataYesterday = await getDocs(queryYesterday)
+		const countsYesterday = new Map()
+		const countsThreeDays = new Map()
+		const countsSevenDays = new Map()
 
-			const queryThreeDays = buildActiveReportsQuery({
-				topic: tempTopics[index],
-				dateFrom: getStartOfDay(3),
-				dateTo: getEndOfDay(),
-				agencyId: agencyIdFilter,
-				activeExperimentId,
-			})
-			const dataThreeDays = await getDocs(queryThreeDays)
-
-			const querySevenDays = buildActiveReportsQuery({
-				topic: tempTopics[index],
-				dateFrom: getStartOfDay(7),
-				dateTo: getEndOfDay(),
-				agencyId: agencyIdFilter,
-				activeExperimentId,
-			})
-			const dataSevenDays = await getDocs(querySevenDays)
-
-			// Add topics with reports to respective arrays
-			if (dataYesterday.size !== 0) {
-				topicsYesterday.push([tempTopics[index], dataYesterday.size])
-			}
-			if (dataThreeDays.size !== 0) {
-				topicsThreeDays.push([tempTopics[index], dataThreeDays.size])
-			}
-			if (dataSevenDays.size !== 0) {
-				topicsSevenDays.push([tempTopics[index], dataSevenDays.size])
-			}
+		const bump = (map, topic) => {
+			map.set(topic, (map.get(topic) || 0) + 1)
 		}
-		
+
+		try {
+			const rangeQuery = buildActiveReportsQuery({
+				dateFrom: rangeFrom,
+				dateTo: rangeTo,
+				agencyId: agencyIdFilter,
+				activeExperimentId,
+			})
+			const snapshot = await getDocs(rangeQuery)
+
+			for (const reportDoc of snapshot.docs) {
+				const data = reportDoc.data()
+				const topic = data?.topic
+				if (!topic || !activeTopicSet.has(topic)) continue
+
+				const ms = createdDateToMs(data?.createdDate)
+				if (ms === null || ms < sevenDaysFromMs || ms >= rangeToMs) continue
+
+				bump(countsSevenDays, topic)
+				if (ms >= threeDaysFromMs) bump(countsThreeDays, topic)
+				if (ms >= yesterdayFromMs) bump(countsYesterday, topic)
+			}
+		} catch (error) {
+			console.error('Overview graph range query failed:', error)
+		}
+
+		const toPairs = (map) =>
+			[...map.entries()].filter(([, count]) => count > 0)
+
+		const topicsYesterday = toPairs(countsYesterday)
+		const topicsThreeDays = toPairs(countsThreeDays)
+		const topicsSevenDays = toPairs(countsSevenDays)
+
 		// Determine number of trending topics to display (max 3)
-		const numTopics = []
-		const numTopicsYesterday = topicsYesterday.length > 2 ? 3 : topicsYesterday.length
-		numTopics.push(numTopicsYesterday)
-		const numTopicsThreeDays = topicsThreeDays.length > 2 ? 3 : topicsThreeDays.length
-		numTopics.push(numTopicsThreeDays)
-		const numTopicsSevenDays = topicsSevenDays.length > 2 ? 3 : topicsSevenDays.length
-		numTopics.push(numTopicsSevenDays)
-		
+		const numTopics = [
+			topicsYesterday.length > 2 ? 3 : topicsYesterday.length,
+			topicsThreeDays.length > 2 ? 3 : topicsThreeDays.length,
+			topicsSevenDays.length > 2 ? 3 : topicsSevenDays.length,
+		]
+
 		setNumTrendingTopics(numTopics)
-		
-		// Sort topics by report count (descending) and limit to top 3
+
 		const sortedYesterday = [...topicsYesterday].sort((a, b) => b[1] - a[1]).slice(0, numTopics[0])
 		const sortedThreeDays = [...topicsThreeDays].sort((a, b) => b[1] - a[1]).slice(0, numTopics[1])
 		const sortedSevenDays = [...topicsSevenDays].sort((a, b) => b[1] - a[1]).slice(0, numTopics[2])
-		
-		// Prepare data for visualization with header row
+
 		const trendingTopics = [["Topics", "Number Reports"]]
 		setYesterdayReports(trendingTopics.concat(sortedYesterday))
 		setThreeDayReports(trendingTopics.concat(sortedThreeDays))
 		setSevenDayReports(trendingTopics.concat(sortedSevenDays))
-		
+
 		setLoaded(true)
 		setLoading(false)
 	}


### PR DESCRIPTION
## Summary
- Introduce brand palette (Futuristic Robot), Inter font, and Material Tailwind theme overrides across auth, layout, modals, and dashboard UI
- Migrate overlays/nav actions to MT Dialog / IconButton patterns and tighten radii/spacing for consistency
- Fix comparison-chart agency scoping so report queries wait for `agencyId` under the new Firestore rules
- Optimize overview + comparison report fetching (range queries + client-side bucketing) to cut Firestore reads
- Count report label usage by `agencyId`; add composite index support where needed

## Test plan
- [ ] Login / signup / reset / verify pages render with brand colors and usable forms
- [ ] Admin + agency: open key modals (report, confirm/delete, agency/user, tags/labels) — open/close, submit, focus trap OK
- [ ] Agency dashboard: overview trending pies load without permission errors
- [ ] Agency dashboard: comparison chart — pick topics + valid date range, plot, refresh, clear; no permission overlay
- [ ] Admin dashboard: comparison chart loads all-agency topics and plots without errors
- [ ] Spot-check Navbar / Headbar / Toggle and a reports list row for color/radius consistency
- [ ] Confirm label usage counts still update correctly for agency-scoped reports