### PR TITLE
Bug/login race

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -62,12 +62,8 @@ env:
       - BUILD
       - RUNTIME
 
-  # Optional: only for dev/debug; omit or use a separate backend for production
-  - variable: NEXT_PUBLIC_FIREBASE_APPCHECK_DEBUG_TOKEN
-    secret: NEXT_PUBLIC_FIREBASE_APPCHECK_DEBUG_TOKEN
-    availability:
-      - BUILD
-      - RUNTIME
+  # Do NOT set NEXT_PUBLIC_FIREBASE_APPCHECK_DEBUG_TOKEN on this production backend.
+  # Debug tokens are for local/dev only (see config/firebase.js + local .env).
 
   # Set to your App Hosting URL (or custom domain) after first deploy; used for auth email links
   - variable: NEXT_PUBLIC_APP_URL

--- a/components/layout/ProtectedRoute.jsx
+++ b/components/layout/ProtectedRoute.jsx
@@ -11,20 +11,30 @@
 import { useRouter } from 'next/router'
 import React, { useEffect } from 'react'
 import { useAuth } from '../../context/AuthContext'
+import LoadingSpinner from '../ui/LoadingSpinner'
 
 const ProtectedRoute = ({ children }) => {
+	const { user, loading } = useAuth()
+	const router = useRouter()
 
-    const { user } = useAuth()
-    const router = useRouter()
+	useEffect(() => {
+		// Wait until auth has resolved — redirecting while loading===true and
+		// user===null races the post-login onAuthStateChanged → setUser path.
+		if (!loading && !user) {
+			router.push('/login')
+		}
+	}, [router, user, loading])
 
-    useEffect(() => {
-        if (!user) {
-            router.push('/login')
-        }
+	if (loading) {
+		return (
+			<div className="min-h-screen w-full flex flex-col items-center justify-center bg-[#D3D3D3] gap-3">
+				<LoadingSpinner className="h-12 w-12 text-[#2E3B4E]" />
+				<p className="text-sm text-gray-600">Loading…</p>
+			</div>
+		)
+	}
 
-    }, [router, user])
-    
-    return <>{user ? children : null}</>
+	return <>{user ? children : null}</>
 }
 
 export default ProtectedRoute

--- a/context/AuthContext.jsx
+++ b/context/AuthContext.jsx
@@ -72,6 +72,8 @@ export const AuthContextProvider = ({children}) => {
 
     const [user, setUser] = useState(null)
     const [loading, setLoading] = useState(true)
+    /** False until the first ID-token claims read finishes (or sign-out clears them). */
+    const [claimsReady, setClaimsReady] = useState(false)
     const [userRole, setUserRole] = useState('user')
     const [customClaims, setCustomClaims] = useState({
         agency: false,
@@ -172,6 +174,7 @@ export const AuthContextProvider = ({children}) => {
                     displayName: user.displayName,
                     email: user.email,
                 })
+                setClaimsReady(false)
                 setLoading(false)
 
                 // Custom claims (includes agencyId) — non-blocking
@@ -181,6 +184,9 @@ export const AuthContextProvider = ({children}) => {
                     })
                     .catch((error) => {
                         console.log('Error fetching custom claims:', error)
+                    })
+                    .finally(() => {
+                        setClaimsReady(true)
                     })
 
                 // Local tracking id from locations/Texas — non-blocking
@@ -201,6 +207,7 @@ export const AuthContextProvider = ({children}) => {
             } else {
                 setUser(null)
                 setCustomClaims(normalizeCustomClaims(null))
+                setClaimsReady(true)
                 setLoading(false)
             }
         })
@@ -537,6 +544,7 @@ export const AuthContextProvider = ({children}) => {
         <AuthContext.Provider value={{
             user,
             loading,
+            claimsReady,
             customClaims,
             setCustomClaims,
             functionsReady: !!functionsInstance,

--- a/context/AuthContext.jsx
+++ b/context/AuthContext.jsx
@@ -152,42 +152,57 @@ export const AuthContextProvider = ({children}) => {
 
     /**
      * Effect hook to monitor authentication state changes.
-     * 
-     * This effect sets up a listener for Firebase authentication state changes.
-     * When a user signs in, it fetches their location data, sets up user state,
-     * and verifies their custom claims for role-based access control.
+     *
+     * Sets React `user` as soon as Firebase Auth reports a session (so route
+     * guards do not bounce a successful login). Location id and custom claims
+     * are loaded afterward without blocking that initial setUser.
      */
     useEffect(() => {
-        const unsubscribe = onAuthStateChanged(auth, async (user) => {
+        const unsubscribe = onAuthStateChanged(auth, (user) => {
             if (user) {
-                // Fetch location data for user identification
-                const ref = await getDoc(doc(db, "locations", "Texas"))
-                const localId = ref.data()['Austin']
-                
+                // Set auth user immediately so login → /dashboard is not bounced by
+                // ProtectedRoute while Firestore/App Check are still warming up.
+                const cachedLocalId =
+                    typeof window !== 'undefined'
+                        ? localStorage.getItem('userId')
+                        : null
                 setUser({
-                    uid: localId, // Local identifier for user tracking
+                    uid: cachedLocalId || user.uid,
                     accountId: user.uid,
                     displayName: user.displayName,
-                    email: user.email
+                    email: user.email,
                 })
-                localStorage.setItem("userId", localId)
-                
-                // Verify user's custom claims for role-based access (includes agencyId)
+                setLoading(false)
+
+                // Custom claims (includes agencyId) — non-blocking
                 user.getIdTokenResult(true)
                     .then((idTokenResult) => {
-                        const next = normalizeCustomClaims(idTokenResult.claims)
-                        setCustomClaims(next)
+                        setCustomClaims(normalizeCustomClaims(idTokenResult.claims))
                     })
                     .catch((error) => {
-                        console.log("Error fetching custom claims:", error);
-                    });
-              
+                        console.log('Error fetching custom claims:', error)
+                    })
+
+                // Local tracking id from locations/Texas — non-blocking
+                getDoc(doc(db, 'locations', 'Texas'))
+                    .then((ref) => {
+                        const localId = ref.data()?.['Austin']
+                        if (!localId) return
+                        localStorage.setItem('userId', localId)
+                        setUser((prev) =>
+                            prev && prev.accountId === user.uid
+                                ? { ...prev, uid: localId }
+                                : prev,
+                        )
+                    })
+                    .catch((error) => {
+                        console.log('Error fetching location id:', error)
+                    })
             } else {
-                // Clear user state when signed out
                 setUser(null)
                 setCustomClaims(normalizeCustomClaims(null))
+                setLoading(false)
             }
-            setLoading(false)
         })
         return () => unsubscribe()
     }, [])
@@ -521,6 +536,7 @@ export const AuthContextProvider = ({children}) => {
     return (
         <AuthContext.Provider value={{
             user,
+            loading,
             customClaims,
             setCustomClaims,
             functionsReady: !!functionsInstance,

--- a/pages/dashboard.jsx
+++ b/pages/dashboard.jsx
@@ -20,8 +20,7 @@
  */
 
 import { useRouter } from 'next/router'
-import React from 'react'
-import { useState, useEffect } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import Home from '../components/dashboard/Home'
 import Profile from '../components/profile/Profile'
 import Settings from '../components/admin/Settings'
@@ -34,6 +33,34 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Head from 'next/head'
 import HelpRequests from '../components/admin/HelpRequests'
 
+/** Stable view names synced to `?view=` so refresh restores the active tab. */
+const VIEW_BY_TAB = [
+	'home',
+	'profile',
+	'settings',
+	'users',
+	'agencies',
+	'help',
+]
+
+/**
+ * Whether a tab index is allowed for the given claims.
+ *
+ * @param {number} tabIndex
+ * @param {{admin: boolean, agency: boolean}} claims
+ * @returns {boolean}
+ */
+function isTabAllowed(tabIndex, claims) {
+	if (tabIndex === 1) return true
+	if (tabIndex === 0 || tabIndex === 2 || tabIndex === 3) {
+		return !!(claims.admin || claims.agency)
+	}
+	if (tabIndex === 4 || tabIndex === 5) {
+		return !!claims.admin
+	}
+	return false
+}
+
 /**
  * Dashboard Page
  *
@@ -42,47 +69,89 @@ import HelpRequests from '../components/admin/HelpRequests'
  * @returns {JSX.Element} The rendered dashboard page
  */
 const Dashboard = () => {
-	const {
-		user,
-		logout,
-		customClaims,
-		verifyPrivilege,
-		changeRole,
-		addAdminRole,
-		addAgencyRole,
-		viewRole,
-	} = useAuth()
-	const [tab, setTab] = useState(0)
+	const { customClaims, claimsReady } = useAuth()
 	const router = useRouter()
 
 	const [agencyUpdateSubmitted, setAgencyUpdateSubmitted] = useState(0)
 
-	const [newReportModal,setNewReportModal] = useState(false)
-	const [newReportSubmitted,setNewReportSubmitted] = useState(0)
+	const [newReportModal, setNewReportModal] = useState(false)
+	const [newReportSubmitted, setNewReportSubmitted] = useState(0)
 
 	const handleNewReportSubmit = () => {
-		// increment the newReportSubmitted
 		setNewReportSubmitted((prevState) => prevState + 1)
 		setNewReportModal(false)
 	}
 
 	const handleNewReportClick = () => {
-		setNewReportModal(true) // Open the modal when the button is clicked
+		setNewReportModal(true)
 	}
 
 	const handleAgencyUpdateSubmit = () => {
-		// increment the agencyUpdateSubmitted
 		setAgencyUpdateSubmitted((prevState) => prevState + 1)
 	}
 
+	const viewFromQuery = useMemo(() => {
+		const raw = router.query.view
+		return typeof raw === 'string' ? raw : null
+	}, [router.query.view])
+
+	const tab = useMemo(() => {
+		const idx = viewFromQuery ? VIEW_BY_TAB.indexOf(viewFromQuery) : -1
+		return idx >= 0 ? idx : 0
+	}, [viewFromQuery])
+
+	const setTab = useCallback(
+		(nextTab) => {
+			const view = VIEW_BY_TAB[nextTab] ?? 'home'
+			if (viewFromQuery === view) return
+			router.replace(
+				{
+					pathname: router.pathname,
+					query: { ...router.query, view },
+				},
+				undefined,
+				{ shallow: true },
+			)
+		},
+		[router, viewFromQuery],
+	)
+
+	// Persist / restore view via URL; only clamp roles after claims are known.
+	// (Previously an effect treated the default {admin:false,agency:false} as
+	// "regular user" and forced Profile on every refresh before claims loaded.)
 	useEffect(() => {
-		// AuthContext owns customClaims (including agencyId). Gate the home tab from
-		// claims state — avoid auth.currentUser?.getIdTokenResult().then(...) which
-		// throws when currentUser is null (optional chain yields undefined).
-		if (!customClaims.admin && !customClaims.agency) {
-			setTab(1)
+		if (!router.isReady || !claimsReady) return
+
+		const isPrivileged = !!(customClaims.admin || customClaims.agency)
+		const requestedIdx = viewFromQuery
+			? VIEW_BY_TAB.indexOf(viewFromQuery)
+			: -1
+
+		let nextIdx = requestedIdx
+		if (nextIdx < 0 || !isTabAllowed(nextIdx, customClaims)) {
+			nextIdx = isPrivileged ? 0 : 1
 		}
-	}, [customClaims.admin, customClaims.agency])
+
+		const nextView = VIEW_BY_TAB[nextIdx]
+		if (viewFromQuery !== nextView) {
+			router.replace(
+				{
+					pathname: router.pathname,
+					query: { ...router.query, view: nextView },
+				},
+				undefined,
+				{ shallow: true },
+			)
+		}
+	}, [
+		router,
+		router.isReady,
+		claimsReady,
+		customClaims,
+		customClaims.admin,
+		customClaims.agency,
+		viewFromQuery,
+	])
 
 	return (
 		<>
@@ -135,12 +204,10 @@ export default Dashboard
 
 /* Allows us to retrieve the json files from the pubic folder so that we can translate on the component pages*/
 export async function getStaticProps(context) {
-	// extract the locale identifier from the URL
 	const { locale } = context
 
 	return {
 		props: {
-			// pass the translation props to the page component
 			...(await serverSideTranslations(locale, [
 				'Home',
 				'Report',

--- a/pages/login.jsx
+++ b/pages/login.jsx
@@ -226,10 +226,12 @@ const Login = () => {
 									<input
 										type="checkbox"
 										name="remember-me"
-										className="form-checkbox rounded-sm border-transparent focus:border-transparent focus:ring-0"
-										onChange={handleChange}
+										id="remember-me"
+										className="form-checkbox rounded-sm border-gray-400 text-[#2E3B4E] focus:ring-[#2E3B4E]"
 									/>
-									<span className="text-sm p-2">{t('remember')}</span>
+									<label htmlFor="remember-me" className="text-sm p-2">
+										{t('remember')}
+									</label>
 								</div>
 								<Link
 									href="/resetPassword"


### PR DESCRIPTION
## Summary
- Fix first-login bounce: set auth `user` immediately and wait for auth `loading` in `ProtectedRoute` so `/dashboard` is not redirected back to `/login` before context settles.
- Persist dashboard tabs in `?view=` and gate role-based tab clamping on `claimsReady`, so refresh no longer forces Profile from the default empty claims state.
- Remove App Check debug token from production App Hosting config (local/dev only).

## Test plan
- [ ] Log in once with admin creds on a clean session — lands on dashboard without a second attempt
- [ ] Open Home, Users, Agencies, etc.; refresh — same view restores via `?view=`
- [ ] Refresh as admin on `/dashboard` with no query — lands on Home, not Profile
- [ ] Non-privileged user still lands on Profile and cannot open admin-only views
- [ ] Confirm production App Hosting no longer injects `NEXT_PUBLIC_FIREBASE_APPCHECK_DEBUG_TOKEN` after deploy