### PR TITLE
style(table): update background color for investigation status and adjust label color for 'Misinfo'

### DIFF
--- a/components/table/TableBody.jsx
+++ b/components/table/TableBody.jsx
@@ -63,7 +63,7 @@ const TableBody = ({
               onClick={() => onReportModalShow(report.reportID)}
               className={`p-4 border-b border-blue-gray-50 cursor-pointer ${
                 needsInvestigation
-                  ? 'bg-yellow-50 hover:bg-yellow-100'
+                  ? 'bg-red-50 hover:bg-red-100'
                   : 'hover:bg-gray-100'
               }`}>
               {columns.map(({ accessor }) => {

--- a/config/labels.js
+++ b/config/labels.js
@@ -17,7 +17,7 @@ export const MAX_CUSTOM_LABELS = 6
 
 export const DEFAULT_LABEL_COLORS = {
 	'To Investigate': '#071f31',
-	Misinfo: '#ba401d',
+	Misinfo: '#C42B47',
 	'Not Misinfo': '#95a8b5',
 	Other: '#d1dfea',
 }


### PR DESCRIPTION
Change the background color for rows needing investigation from yellow to red in the TableBody component to enhance visibility. Additionally, update the default color for the 'Misinfo' label to a more distinct shade for better differentiation.