### PR TITLE
Feat/colors edit

### DIFF
--- a/components/admin/Appearance.jsx
+++ b/components/admin/Appearance.jsx
@@ -1,0 +1,167 @@
+/**
+ * Admin Appearance settings — report table chrome and future UI tokens.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react'
+import { Button, Typography } from '@material-tailwind/react'
+import { db } from '../../config/firebase'
+import {
+	DEFAULT_APPEARANCE_CONFIG,
+	getAppearanceConfig,
+	saveAppearanceConfig,
+} from '../../utils/appearance-config'
+
+/**
+ * @param {{ bg: string, hover: string }} row
+ */
+function ColorPreview({ bg, hover }) {
+	const [hovered, setHovered] = useState(false)
+	return (
+		<div
+			className="rounded-md border border-blue-gray-100 px-4 py-3 text-sm text-gray-700 transition-colors"
+			style={{ backgroundColor: hovered ? hover : bg }}
+			onMouseEnter={() => setHovered(true)}
+			onMouseLeave={() => setHovered(false)}>
+			Investigation row preview (hover to see hover color)
+		</div>
+	)
+}
+
+const Appearance = () => {
+	const [bg, setBg] = useState(
+		DEFAULT_APPEARANCE_CONFIG.reportTable.investigationRow.bg,
+	)
+	const [hover, setHover] = useState(
+		DEFAULT_APPEARANCE_CONFIG.reportTable.investigationRow.hover,
+	)
+	const [loading, setLoading] = useState(true)
+	const [busy, setBusy] = useState(false)
+	const [status, setStatus] = useState('')
+
+	const loadConfig = useCallback(async () => {
+		setLoading(true)
+		setStatus('')
+		try {
+			const config = await getAppearanceConfig(db)
+			setBg(config.reportTable.investigationRow.bg)
+			setHover(config.reportTable.investigationRow.hover)
+		} catch (err) {
+			console.error(err)
+			setStatus('Failed to load appearance settings.')
+		} finally {
+			setLoading(false)
+		}
+	}, [])
+
+	useEffect(() => {
+		loadConfig()
+	}, [loadConfig])
+
+	const handleSave = async () => {
+		setBusy(true)
+		setStatus('')
+		try {
+			const saved = await saveAppearanceConfig(db, {
+				reportTable: {
+					investigationRow: { bg, hover },
+				},
+			})
+			setBg(saved.reportTable.investigationRow.bg)
+			setHover(saved.reportTable.investigationRow.hover)
+			setStatus('Appearance settings saved.')
+		} catch (err) {
+			console.error(err)
+			setStatus('Failed to save appearance settings.')
+		} finally {
+			setBusy(false)
+		}
+	}
+
+	const handleReset = () => {
+		setBg(DEFAULT_APPEARANCE_CONFIG.reportTable.investigationRow.bg)
+		setHover(DEFAULT_APPEARANCE_CONFIG.reportTable.investigationRow.hover)
+		setStatus('Reset to defaults (not saved yet).')
+	}
+
+	return (
+		<div className="p-6 max-w-3xl">
+			<Typography variant="h4" color="blue" className="mb-2">
+				Appearance
+			</Typography>
+			<p className="text-sm text-gray-600 mb-6">
+				Configure shared dashboard colors. Changes apply for all signed-in users.
+			</p>
+
+			<div className="mb-8 p-6 bg-white rounded-lg border border-blue-gray-100">
+				<Typography variant="h5" color="blue" className="mb-4">
+					Report table
+				</Typography>
+				<p className="text-sm text-gray-600 mb-4">
+					Highlight color for rows labeled &quot;To Investigate&quot; (or missing a
+					label).
+				</p>
+
+				{loading ? (
+					<p className="text-sm text-gray-500">Loading…</p>
+				) : (
+					<div className="flex flex-col gap-4 max-w-md">
+						<label className="flex flex-col gap-1">
+							<span className="text-sm font-medium text-gray-700">
+								Investigation row background
+							</span>
+							<input
+								type="color"
+								value={bg}
+								onChange={(e) => setBg(e.target.value)}
+								className="h-10 w-full cursor-pointer rounded-md border border-gray-200"
+								aria-label="Investigation row background"
+							/>
+							<span className="text-xs font-mono text-gray-500">{bg}</span>
+						</label>
+
+						<label className="flex flex-col gap-1">
+							<span className="text-sm font-medium text-gray-700">
+								Investigation row hover
+							</span>
+							<input
+								type="color"
+								value={hover}
+								onChange={(e) => setHover(e.target.value)}
+								className="h-10 w-full cursor-pointer rounded-md border border-gray-200"
+								aria-label="Investigation row hover"
+							/>
+							<span className="text-xs font-mono text-gray-500">{hover}</span>
+						</label>
+
+						<ColorPreview bg={bg} hover={hover} />
+
+						<div className="flex flex-wrap gap-2 pt-2">
+							<Button
+								size="sm"
+								color="blue"
+								disabled={busy}
+								onClick={handleSave}>
+								Save
+							</Button>
+							<Button
+								size="sm"
+								variant="outlined"
+								disabled={busy}
+								onClick={handleReset}>
+								Reset to defaults
+							</Button>
+						</div>
+
+						{status && (
+							<p className="text-sm text-gray-600" role="status">
+								{status}
+							</p>
+						)}
+					</div>
+				)}
+			</div>
+		</div>
+	)
+}
+
+export default Appearance

--- a/components/layout/Navbar.jsx
+++ b/components/layout/Navbar.jsx
@@ -354,8 +354,27 @@ const Navbar = ({
 							)}
 						</div>
 						
-						{/* Bottom section - Help and Profile */}
+						{/* Bottom section - Appearance, Help and Profile */}
 						<div className="self-end">
+							{/* Appearance - Admin only */}
+							{customClaims.admin && (
+								<>
+									<IconButton
+										variant="text"
+										onClick={() => handleTabNavigation(6)}
+										className={navIconClass('tooltip-appearance', tab === 6)}
+										aria-label="Appearance">
+										<IoSettingsOutline size={30} />
+									</IconButton>
+									<Tooltip
+										anchorSelect=".tooltip-appearance"
+										place="bottom"
+										delayShow={500}>
+										Appearance
+									</Tooltip>
+								</>
+							)}
+
 							{/* Help - Admin and Agency users */}
 							{(customClaims.admin || customClaims.agency) && (
 								<>

--- a/components/modals/admin/AgencyModal.jsx
+++ b/components/modals/admin/AgencyModal.jsx
@@ -183,7 +183,9 @@ const AgencyModal = ({
 									actionText="Choose image"
 								/>
 							</div>
-							<Button type="submit">Update Agency</Button>
+							<Button type="submit" size="sm">
+								Update Agency
+							</Button>
 						</div>
 					</form>
 				</DialogBody>

--- a/components/reports/ReportsSection.jsx
+++ b/components/reports/ReportsSection.jsx
@@ -60,6 +60,10 @@ import {
 	resolveAgencyIdForReport,
 } from '../../utils/label-tags'
 import { formatLocationPart } from '../../utils/format-location'
+import {
+	DEFAULT_INVESTIGATION_ROW,
+	getAppearanceConfig,
+} from '../../utils/appearance-config'
 // Icons
 import {
 	Button,
@@ -275,6 +279,9 @@ const ReportsSection = ({
 	const [changeStatus, setChangeStatus] = useState('') // Status change tracking
 	const [agencyLabelColors, setAgencyLabelColors] = useState({})
 	const [agencyLabelColorsByAgency, setAgencyLabelColorsByAgency] = useState({})
+	const [investigationHighlight, setInvestigationHighlight] = useState(
+		DEFAULT_INVESTIGATION_ROW,
+	)
 	const [postedDate, setPostedDate] = useState('') // Formatted posted date
 	const [update, setUpdate] = useState(false) // Update trigger
 	const [deleteModal, setDeleteModal] = useState(false) // Delete modal visibility
@@ -1178,6 +1185,22 @@ const ReportsSection = ({
 		}
 	}, [customClaims])
 
+	// Shared appearance (investigation row highlight, etc.)
+	useEffect(() => {
+		let cancelled = false
+		getAppearanceConfig(db)
+			.then((config) => {
+				if (cancelled) return
+				setInvestigationHighlight(config.reportTable.investigationRow)
+			})
+			.catch((err) => {
+				console.error(err)
+			})
+		return () => {
+			cancelled = true
+		}
+	}, [])
+
 	// Agency display name for agency users (prefer claim; avoid agencyUsers collection query)
 	useEffect(() => {
 		if (!isAgency) return
@@ -1498,6 +1521,7 @@ const ReportsSection = ({
 							reportsReadState={reportsReadState}
 							agencyLabelColors={agencyLabelColors}
 							agencyLabelColorsByAgency={agencyLabelColorsByAgency}
+							investigationHighlight={investigationHighlight}
 						/>
 					</table>
 

--- a/components/table/TableBody.jsx
+++ b/components/table/TableBody.jsx
@@ -8,6 +8,7 @@ import {
   getLabelBadgeStyle,
   isInvestigationPending,
 } from '../../config/labels'
+import { DEFAULT_INVESTIGATION_ROW } from '../../utils/appearance-config'
 
 const TableBody = ({
   loadedReports,
@@ -18,6 +19,7 @@ const TableBody = ({
   reportsReadState,
   agencyLabelColors = {},
   agencyLabelColorsByAgency = {},
+  investigationHighlight = DEFAULT_INVESTIGATION_ROW,
 }) => {
   function trimToWordCount(str, wordCount) {
     const words = str.split(' ')
@@ -30,6 +32,10 @@ const TableBody = ({
     }
     return agencyLabelColorsByAgency[report.agency] || {}
   }
+
+  const highlightBg = investigationHighlight?.bg || DEFAULT_INVESTIGATION_ROW.bg
+  const highlightHover =
+    investigationHighlight?.hover || DEFAULT_INVESTIGATION_ROW.hover
 
   return (
     <tbody>
@@ -62,10 +68,25 @@ const TableBody = ({
               key={report.reportID}
               onClick={() => onReportModalShow(report.reportID)}
               className={`p-4 border-b border-blue-gray-50 cursor-pointer ${
+                needsInvestigation ? '' : 'hover:bg-gray-100'
+              }`}
+              style={
+                needsInvestigation ? { backgroundColor: highlightBg } : undefined
+              }
+              onMouseEnter={
                 needsInvestigation
-                  ? 'bg-red-50 hover:bg-red-100'
-                  : 'hover:bg-gray-100'
-              }`}>
+                  ? (e) => {
+                      e.currentTarget.style.backgroundColor = highlightHover
+                    }
+                  : undefined
+              }
+              onMouseLeave={
+                needsInvestigation
+                  ? (e) => {
+                      e.currentTarget.style.backgroundColor = highlightBg
+                    }
+                  : undefined
+              }>
               {columns.map(({ accessor }) => {
                 let tData
                 if (accessor === 'createdDate') {

--- a/components/table/TableBody.jsx
+++ b/components/table/TableBody.jsx
@@ -63,7 +63,7 @@ const TableBody = ({
               onClick={() => onReportModalShow(report.reportID)}
               className={`p-4 border-b border-blue-gray-50 cursor-pointer ${
                 needsInvestigation
-                  ? 'bg-yellow-50 hover:bg-yellow-100'
+                  ? 'bg-red-50 hover:bg-red-100'
                   : 'hover:bg-gray-100'
               }`}>
               {columns.map(({ accessor }) => {

--- a/components/table/TableBody.jsx
+++ b/components/table/TableBody.jsx
@@ -82,9 +82,11 @@ const TableBody = ({
               }
               onMouseLeave={
                 needsInvestigation
-                  ? 'bg-red-50 hover:bg-red-100'
-                  : 'hover:bg-gray-100'
-              }`}>
+                  ? (e) => {
+                      e.currentTarget.style.backgroundColor = highlightBg
+                    }
+                  : undefined
+              }>
               {columns.map(({ accessor }) => {
                 let tData
                 if (accessor === 'createdDate') {

--- a/config/labels.js
+++ b/config/labels.js
@@ -17,7 +17,7 @@ export const MAX_CUSTOM_LABELS = 6
 
 export const DEFAULT_LABEL_COLORS = {
 	'To Investigate': '#071f31',
-	Misinfo: '#ba401d',
+	Misinfo: '#C42B47',
 	'Not Misinfo': '#95a8b5',
 	Other: '#d1dfea',
 }

--- a/context/AuthContext.jsx
+++ b/context/AuthContext.jsx
@@ -282,7 +282,7 @@ export const AuthContextProvider = ({children}) => {
      */
     const verifyEmail = (user) => {
         return new Promise((resolve, reject) => {
-            const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://truthsleuthlocal.netlify.app';
+            const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://truthsleuthlocal--misinfo-5d004.us-central1.hosted.app';
             const actionCodeSettings = {
                 'url': `${baseUrl}/login`,
                 'handleCodeInApp': true,
@@ -517,12 +517,12 @@ export const AuthContextProvider = ({children}) => {
      * await sendSignIn('user@example.com');
      */
     const sendSignIn = async (email) => {
-        // Continue URL for email action links: current origin in browser, else configured app URL
-        const origin =
-            typeof window !== 'undefined' && window.location?.origin
-                ? window.location.origin
-                : (process.env.NEXT_PUBLIC_APP_URL || 'https://truthsleuthlocal.netlify.app')
-        const baseUrl = `${origin.replace(/\/$/, '')}/signup`
+        // Always use configured app URL so invites from localhost still point at the live app
+        const origin = (
+            process.env.NEXT_PUBLIC_APP_URL ||
+            'https://truthsleuthlocal--misinfo-5d004.us-central1.hosted.app'
+        ).replace(/\/$/, '')
+        const baseUrl = `${origin}/signup`
 
         const actionCodeSettings = {
             url: baseUrl,

--- a/firestore.rules
+++ b/firestore.rules
@@ -42,6 +42,11 @@ service cloud.firestore {
       allow write: if isAdmin();
     }
 
+    match /settings/appearance {
+      allow read: if isSignedIn();
+      allow write: if isAdmin();
+    }
+
     match /tagSystems/{docId} {
       allow read: if isSignedIn();
       allow write: if isAdmin();

--- a/pages/dashboard.jsx
+++ b/pages/dashboard.jsx
@@ -32,6 +32,7 @@ import AgencyReportModal from '../components/modals/reports/AgencyReportModal'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Head from 'next/head'
 import HelpRequests from '../components/admin/HelpRequests'
+import Appearance from '../components/admin/Appearance'
 
 /** Stable view names synced to `?view=` so refresh restores the active tab. */
 const VIEW_BY_TAB = [
@@ -41,6 +42,7 @@ const VIEW_BY_TAB = [
 	'users',
 	'agencies',
 	'help',
+	'appearance',
 ]
 
 /**
@@ -55,7 +57,7 @@ function isTabAllowed(tabIndex, claims) {
 	if (tabIndex === 0 || tabIndex === 2 || tabIndex === 3) {
 		return !!(claims.admin || claims.agency)
 	}
-	if (tabIndex === 4 || tabIndex === 5) {
+	if (tabIndex === 4 || tabIndex === 5 || tabIndex === 6) {
 		return !!claims.admin
 	}
 	return false
@@ -186,6 +188,7 @@ const Dashboard = () => {
 						<Agencies handleAgencyUpdateSubmit={handleAgencyUpdateSubmit} />
 					)}
 					{tab == 5 && customClaims.admin && <HelpRequests />}
+					{tab == 6 && customClaims.admin && <Appearance />}
 				</div>
 				{/* Render the AgencyReportModal */}
 				{newReportModal && (

--- a/utils/appearance-config.js
+++ b/utils/appearance-config.js
@@ -1,0 +1,96 @@
+/**
+ * Shared appearance / UI theme defaults for the dashboard.
+ * Stored in Firestore `settings/appearance` (signed-in read, admin write).
+ */
+
+import { doc, getDoc, setDoc } from 'firebase/firestore'
+
+export const APPEARANCE_SETTINGS_COLLECTION = 'settings'
+export const APPEARANCE_SETTINGS_DOC_ID = 'appearance'
+
+/** Tailwind red-50 / red-100 — matches previous hardcoded investigation row classes. */
+export const DEFAULT_INVESTIGATION_ROW = {
+	bg: '#fef2f2',
+	hover: '#fee2e2',
+}
+
+/** @type {{ reportTable: { investigationRow: { bg: string, hover: string } } }} */
+export const DEFAULT_APPEARANCE_CONFIG = {
+	reportTable: {
+		investigationRow: { ...DEFAULT_INVESTIGATION_ROW },
+	},
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string | null}
+ */
+function normalizeHex(value) {
+	if (typeof value !== 'string') return null
+	const trimmed = value.trim()
+	if (/^#[0-9a-fA-F]{6}$/.test(trimmed)) {
+		return trimmed.toLowerCase()
+	}
+	if (/^#[0-9a-fA-F]{3}$/.test(trimmed)) {
+		const [, r, g, b] = trimmed
+		return `#${r}${r}${g}${g}${b}${b}`.toLowerCase()
+	}
+	return null
+}
+
+/**
+ * Merges raw Firestore data with defaults so missing fields are safe.
+ *
+ * @param {unknown} raw
+ * @returns {{ reportTable: { investigationRow: { bg: string, hover: string } } }}
+ */
+export function normalizeAppearanceConfig(raw) {
+	const source =
+		raw && typeof raw === 'object' ? /** @type {Record<string, unknown>} */ (raw) : {}
+	const reportTable =
+		source.reportTable && typeof source.reportTable === 'object'
+			? /** @type {Record<string, unknown>} */ (source.reportTable)
+			: {}
+	const investigationRow =
+		reportTable.investigationRow && typeof reportTable.investigationRow === 'object'
+			? /** @type {Record<string, unknown>} */ (reportTable.investigationRow)
+			: {}
+
+	return {
+		reportTable: {
+			investigationRow: {
+				bg:
+					normalizeHex(investigationRow.bg) ||
+					DEFAULT_APPEARANCE_CONFIG.reportTable.investigationRow.bg,
+				hover:
+					normalizeHex(investigationRow.hover) ||
+					DEFAULT_APPEARANCE_CONFIG.reportTable.investigationRow.hover,
+			},
+		},
+	}
+}
+
+/**
+ * @param {import('firebase/firestore').Firestore} db
+ * @returns {Promise<{ reportTable: { investigationRow: { bg: string, hover: string } } }>}
+ */
+export async function getAppearanceConfig(db) {
+	const ref = doc(db, APPEARANCE_SETTINGS_COLLECTION, APPEARANCE_SETTINGS_DOC_ID)
+	const snap = await getDoc(ref)
+	if (!snap.exists()) {
+		return normalizeAppearanceConfig(null)
+	}
+	return normalizeAppearanceConfig(snap.data())
+}
+
+/**
+ * @param {import('firebase/firestore').Firestore} db
+ * @param {{ reportTable?: { investigationRow?: { bg?: string, hover?: string } } }} config
+ * @returns {Promise<{ reportTable: { investigationRow: { bg: string, hover: string } } }>}
+ */
+export async function saveAppearanceConfig(db, config) {
+	const normalized = normalizeAppearanceConfig(config)
+	const ref = doc(db, APPEARANCE_SETTINGS_COLLECTION, APPEARANCE_SETTINGS_DOC_ID)
+	await setDoc(ref, normalized, { merge: true })
+	return normalized
+}


### PR DESCRIPTION
## Summary
- Add an admin-only **Appearance** dashboard view (`?view=appearance`) via a navbar settings cog
- Persist investigation-row highlight colors in Firestore `settings/appearance` (signed-in read / admin write)
- Apply those colors on the reports table instead of hardcoded Tailwind red classes
- Also updates default Misinfo badge color to `#C42B47`

## Test plan
- [ ] As admin, open Appearance from the navbar cog; page loads without permission errors
- [ ] Change investigation row bg/hover, Save, confirm status message and Firestore `settings/appearance` updates
- [ ] Reset to defaults (draft), then Save; confirm red-50 / red-100 hex values
- [ ] On Home, confirm “To Investigate” (and unlabeled) rows use the saved colors, including hover
- [ ] As agency user, confirm Appearance cog is hidden but table still shows admin-configured colors
- [ ] Confirm Misinfo label badge uses the new default color where agency overrides aren’t set