### PR TITLE
Fix/report modal

### DIFF
--- a/components/modals/reports/ReportModal.jsx
+++ b/components/modals/reports/ReportModal.jsx
@@ -203,6 +203,9 @@ const ReportModal = ({
 	const [tagLabelMap, setTagLabelMap] = useState({})
 	const [lightboxIndex, setLightboxIndex] = useState(null)
 	const [brokenImageIndexes, setBrokenImageIndexes] = useState(() => new Set())
+	// Delay Dialog open one tick: MT Dialog + Floating UI 0.19 logs aria-hidden
+	// "not contained inside body" when mounting with open={true} immediately.
+	const [dialogOpen, setDialogOpen] = useState(false)
 
 	const reportImages = Array.isArray(report.images)
 		? report.images.filter(Boolean)
@@ -212,6 +215,11 @@ const ReportModal = ({
 		lightboxOpen ? reportImages[lightboxIndex] : null
 	const lightboxImageBroken =
 		lightboxOpen && brokenImageIndexes.has(lightboxIndex)
+
+	useEffect(() => {
+		const id = window.setTimeout(() => setDialogOpen(true), 0)
+		return () => window.clearTimeout(id)
+	}, [])
 
 	useEffect(() => {
 		setBrokenImageIndexes(new Set())
@@ -294,7 +302,7 @@ const ReportModal = ({
 	return (
 		<>
 			<Dialog
-				open
+				open={dialogOpen}
 				handler={handleClose}
 				size="xl"
 				className="report-modal rounded-md"

--- a/components/modals/reports/ReportModal.jsx
+++ b/components/modals/reports/ReportModal.jsx
@@ -41,25 +41,19 @@ import ButtonEmailSend from "../../partials/ButtonEmailSend"
 import ShareReportModal from "../../partials/modals/ShareReportModal"
 import { MdMarkAsUnread, MdMarkEmailRead } from "react-icons/md"
 import Link from "next/link"
-import { createPortal } from "react-dom"
 import {Tooltip} from "react-tooltip";
 // icons
 import { RiMessage2Fill } from "react-icons/ri"
 import { BiEditAlt } from "react-icons/bi"
-// import { BsShareFill } from "react-icons/bs"
 import { BiLinkExternal } from "react-icons/bi";
 import { AiOutlineFieldTime, AiOutlineUser } from "react-icons/ai"
-// import { MdOutlineLocalPhone } from "react-icons/md";
-
 import {
 	IoTrash,
 	IoLocation,
 	IoBusinessOutline,
-	IoClose,
-	IoChevronBackOutline,
-	IoChevronForwardOutline,
 } from "react-icons/io5"
 import ModalCloseButton from "../../ui/ModalCloseButton"
+import ImageLightboxGallery from "../../ui/ImageLightboxGallery"
 import {
 	CUSTOM_LABEL_MAX_LENGTH,
 	DEFAULT_REPORT_LABEL,
@@ -201,8 +195,7 @@ const ReportModal = ({
 	const [images,setImages] = useState([]) // Image gallery state
 	const [shareReportModal, setShareReportModal] = useState(false) // Share modal visibility
 	const [tagLabelMap, setTagLabelMap] = useState({})
-	const [lightboxIndex, setLightboxIndex] = useState(null)
-	const [brokenImageIndexes, setBrokenImageIndexes] = useState(() => new Set())
+	const [lightboxOpen, setLightboxOpen] = useState(false)
 	// Delay Dialog open one tick: MT Dialog + Floating UI 0.19 logs aria-hidden
 	// "not contained inside body" when mounting with open={true} immediately.
 	const [dialogOpen, setDialogOpen] = useState(false)
@@ -210,21 +203,11 @@ const ReportModal = ({
 	const reportImages = Array.isArray(report.images)
 		? report.images.filter(Boolean)
 		: []
-	const lightboxOpen = lightboxIndex !== null
-	const activeLightboxImage =
-		lightboxOpen ? reportImages[lightboxIndex] : null
-	const lightboxImageBroken =
-		lightboxOpen && brokenImageIndexes.has(lightboxIndex)
 
 	useEffect(() => {
 		const id = window.setTimeout(() => setDialogOpen(true), 0)
 		return () => window.clearTimeout(id)
 	}, [])
-
-	useEffect(() => {
-		setBrokenImageIndexes(new Set())
-		setLightboxIndex(null)
-	}, [reportModalId, report?.images])
 
 	useEffect(() => {
 		let cancelled = false
@@ -246,58 +229,6 @@ const ReportModal = ({
 			cancelled = true
 		}
 	}, [report?.agency, report?.agencyId, reportModalId, customClaims?.agencyId])
-
-	useEffect(() => {
-		if (!lightboxOpen) return undefined
-		if (lightboxIndex >= reportImages.length) {
-			setLightboxIndex(reportImages.length > 0 ? reportImages.length - 1 : null)
-			return undefined
-		}
-
-		const onKeyDown = (event) => {
-			if (event.key === 'Escape') {
-				setLightboxIndex(null)
-				return
-			}
-			if (reportImages.length <= 1) return
-			if (event.key === 'ArrowLeft') {
-				setLightboxIndex(
-					(current) =>
-						((current ?? 0) - 1 + reportImages.length) % reportImages.length,
-				)
-			}
-			if (event.key === 'ArrowRight') {
-				setLightboxIndex(
-					(current) => ((current ?? 0) + 1) % reportImages.length,
-				)
-			}
-		}
-
-		document.addEventListener('keydown', onKeyDown)
-		return () => document.removeEventListener('keydown', onKeyDown)
-	}, [lightboxOpen, lightboxIndex, reportImages.length])
-
-	const markImageBroken = (index) => {
-		setBrokenImageIndexes((prev) => {
-			if (prev.has(index)) return prev
-			const next = new Set(prev)
-			next.add(index)
-			return next
-		})
-	}
-
-	const showPrevLightbox = (event) => {
-		event.stopPropagation()
-		setLightboxIndex(
-			(current) =>
-				((current ?? 0) - 1 + reportImages.length) % reportImages.length,
-		)
-	}
-
-	const showNextLightbox = (event) => {
-		event.stopPropagation()
-		setLightboxIndex((current) => ((current ?? 0) + 1) % reportImages.length)
-	}
 
 	return (
 		<>
@@ -480,31 +411,11 @@ const ReportModal = ({
 											Images
 										</Typography>
 										{reportImages.length > 0 ? (
-											<div className='grid grid-cols-4 gap-4 w-full overflow-y-auto'>
-												{reportImages.map((image, i) => (
-													<div className='grid-cols-subgrid' key={i}>
-														{brokenImageIndexes.has(i) ? (
-															<span className="flex min-h-[4.5rem] items-center justify-center rounded-md border border-slate-200 bg-slate-50 px-2 text-center text-xs italic text-gray-400">
-																Image not found
-															</span>
-														) : (
-															<button
-																type="button"
-																onClick={() => setLightboxIndex(i)}
-																className="block w-full overflow-hidden rounded-md border border-slate-200 bg-white transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-400"
-																aria-label={`View image ${i + 1}`}>
-																{/* Plain img: Next Image optimizer fetches without browser Origin and can 401 against Storage */}
-																<img
-																	src={image}
-																	alt={`Report image ${i + 1}`}
-																	className="h-auto w-full object-cover"
-																	onError={() => markImageBroken(i)}
-																/>
-															</button>
-														)}
-													</div>
-												))}
-											</div>
+											<ImageLightboxGallery
+												images={reportImages}
+												altPrefix="Report image"
+												onLightboxChange={setLightboxOpen}
+											/>
 										) : (
 											<Typography variant="small" className="italic" color="gray">
 												No images for this report
@@ -637,65 +548,6 @@ const ReportModal = ({
 					closeModal={setShareReportModal}
 				/>
 			)}
-
-			{activeLightboxImage &&
-				typeof document !== 'undefined' &&
-				createPortal(
-					<div
-						className="fixed inset-0 z-[10001] flex items-center justify-center bg-black/80 p-4"
-						onClick={() => setLightboxIndex(null)}
-						role="dialog"
-						aria-modal="true"
-						aria-label={`Report image ${lightboxIndex + 1}`}>
-						<button
-							type="button"
-							onClick={() => setLightboxIndex(null)}
-							className="absolute right-4 top-4 rounded-full p-1 text-white transition-colors hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white"
-							aria-label="Close image preview">
-							<IoClose className="h-7 w-7" aria-hidden="true" />
-						</button>
-
-						{reportImages.length > 1 && (
-							<>
-								<button
-									type="button"
-									onClick={showPrevLightbox}
-									className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full p-2 text-white transition-colors hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white"
-									aria-label="Previous image">
-									<IoChevronBackOutline className="h-7 w-7" aria-hidden="true" />
-								</button>
-								<button
-									type="button"
-									onClick={showNextLightbox}
-									className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full p-2 text-white transition-colors hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white"
-									aria-label="Next image">
-									<IoChevronForwardOutline className="h-7 w-7" aria-hidden="true" />
-								</button>
-							</>
-						)}
-
-						{lightboxImageBroken ? (
-							<p className="rounded-md bg-white/10 px-4 py-3 text-sm italic text-white/90">
-								Image not found
-							</p>
-						) : (
-							<img
-								src={activeLightboxImage}
-								alt={`Report image ${lightboxIndex + 1}`}
-								className="max-h-[90vh] max-w-full object-contain"
-								onClick={(event) => event.stopPropagation()}
-								onError={() => markImageBroken(lightboxIndex)}
-							/>
-						)}
-
-						{reportImages.length > 1 && (
-							<p className="absolute bottom-4 left-1/2 -translate-x-1/2 text-sm text-white/90">
-								{lightboxIndex + 1} / {reportImages.length}
-							</p>
-						)}
-					</div>,
-					document.body,
-				)}
 		</>
 	)
 }

--- a/components/modals/reports/ReportModal.jsx
+++ b/components/modals/reports/ReportModal.jsx
@@ -7,7 +7,7 @@
  * 
  * Key Features:
  * - Detailed report information display (title, description, links, metadata)
- * - Image gallery with external link support
+ * - Image gallery with lightbox preview
  * - Role-based editing (admin vs agency restrictions)
  * - Read/unread status management
  * - Label assignment and management
@@ -41,7 +41,7 @@ import ButtonEmailSend from "../../partials/ButtonEmailSend"
 import ShareReportModal from "../../partials/modals/ShareReportModal"
 import { MdMarkAsUnread, MdMarkEmailRead } from "react-icons/md"
 import Link from "next/link"
-import Image from "next/image"
+import { createPortal } from "react-dom"
 import {Tooltip} from "react-tooltip";
 // icons
 import { RiMessage2Fill } from "react-icons/ri"
@@ -51,7 +51,14 @@ import { BiLinkExternal } from "react-icons/bi";
 import { AiOutlineFieldTime, AiOutlineUser } from "react-icons/ai"
 // import { MdOutlineLocalPhone } from "react-icons/md";
 
-import { IoTrash, IoLocation, IoBusinessOutline } from "react-icons/io5"
+import {
+	IoTrash,
+	IoLocation,
+	IoBusinessOutline,
+	IoClose,
+	IoChevronBackOutline,
+	IoChevronForwardOutline,
+} from "react-icons/io5"
 import ModalCloseButton from "../../ui/ModalCloseButton"
 import {
 	CUSTOM_LABEL_MAX_LENGTH,
@@ -194,6 +201,22 @@ const ReportModal = ({
 	const [images,setImages] = useState([]) // Image gallery state
 	const [shareReportModal, setShareReportModal] = useState(false) // Share modal visibility
 	const [tagLabelMap, setTagLabelMap] = useState({})
+	const [lightboxIndex, setLightboxIndex] = useState(null)
+	const [brokenImageIndexes, setBrokenImageIndexes] = useState(() => new Set())
+
+	const reportImages = Array.isArray(report.images)
+		? report.images.filter(Boolean)
+		: []
+	const lightboxOpen = lightboxIndex !== null
+	const activeLightboxImage =
+		lightboxOpen ? reportImages[lightboxIndex] : null
+	const lightboxImageBroken =
+		lightboxOpen && brokenImageIndexes.has(lightboxIndex)
+
+	useEffect(() => {
+		setBrokenImageIndexes(new Set())
+		setLightboxIndex(null)
+	}, [reportModalId, report?.images])
 
 	useEffect(() => {
 		let cancelled = false
@@ -216,6 +239,58 @@ const ReportModal = ({
 		}
 	}, [report?.agency, report?.agencyId, reportModalId, customClaims?.agencyId])
 
+	useEffect(() => {
+		if (!lightboxOpen) return undefined
+		if (lightboxIndex >= reportImages.length) {
+			setLightboxIndex(reportImages.length > 0 ? reportImages.length - 1 : null)
+			return undefined
+		}
+
+		const onKeyDown = (event) => {
+			if (event.key === 'Escape') {
+				setLightboxIndex(null)
+				return
+			}
+			if (reportImages.length <= 1) return
+			if (event.key === 'ArrowLeft') {
+				setLightboxIndex(
+					(current) =>
+						((current ?? 0) - 1 + reportImages.length) % reportImages.length,
+				)
+			}
+			if (event.key === 'ArrowRight') {
+				setLightboxIndex(
+					(current) => ((current ?? 0) + 1) % reportImages.length,
+				)
+			}
+		}
+
+		document.addEventListener('keydown', onKeyDown)
+		return () => document.removeEventListener('keydown', onKeyDown)
+	}, [lightboxOpen, lightboxIndex, reportImages.length])
+
+	const markImageBroken = (index) => {
+		setBrokenImageIndexes((prev) => {
+			if (prev.has(index)) return prev
+			const next = new Set(prev)
+			next.add(index)
+			return next
+		})
+	}
+
+	const showPrevLightbox = (event) => {
+		event.stopPropagation()
+		setLightboxIndex(
+			(current) =>
+				((current ?? 0) - 1 + reportImages.length) % reportImages.length,
+		)
+	}
+
+	const showNextLightbox = (event) => {
+		event.stopPropagation()
+		setLightboxIndex((current) => ((current ?? 0) + 1) % reportImages.length)
+	}
+
 	return (
 		<>
 			<Dialog
@@ -224,9 +299,9 @@ const ReportModal = ({
 				size="xl"
 				className="report-modal rounded-md"
 				dismiss={{
-					escapeKey: !shareReportModal,
+					escapeKey: !shareReportModal && !lightboxOpen,
 					outsidePress: (event) => {
-						if (shareReportModal) return false
+						if (shareReportModal || lightboxOpen) return false
 						const target = event.target
 						if (!(target instanceof Element)) return true
 						// Nested share overlay / MT Menu portals sit outside Dialog
@@ -392,33 +467,35 @@ const ReportModal = ({
 									</List>
 
 									{/* Image Gallery */}
-									<div className={`images ${report.images?.length > 0 ? 'mb-12' : 'mb-4'}`}>
+									<div className={`images ${reportImages.length > 0 ? 'mb-12' : 'mb-4'}`}>
 										<Typography variant="h5" color="blue" className="mt-0 mb-4">
 											Images
 										</Typography>
-										{report.images?.length > 0 ? (
+										{reportImages.length > 0 ? (
 											<div className='grid grid-cols-4 gap-4 w-full overflow-y-auto'>
-												{report.images.map((image, i) => {
-													return (
-														<div className='grid-cols-subgrid' key={i}>
-															{image ? (
-																<Link href={image} target='_blank'>
-																	<Image
-																		src={image}
-																		width={400}
-																		height={400}
-																		alt='image'
-																		className="w-auto"
-																	/>
-																</Link>
-															) : (
-																<span className='italic font-light'>
-																	Image not found
-																</span>
-															)}
-														</div>
-													)
-												})}
+												{reportImages.map((image, i) => (
+													<div className='grid-cols-subgrid' key={i}>
+														{brokenImageIndexes.has(i) ? (
+															<span className="flex min-h-[4.5rem] items-center justify-center rounded-md border border-slate-200 bg-slate-50 px-2 text-center text-xs italic text-gray-400">
+																Image not found
+															</span>
+														) : (
+															<button
+																type="button"
+																onClick={() => setLightboxIndex(i)}
+																className="block w-full overflow-hidden rounded-md border border-slate-200 bg-white transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+																aria-label={`View image ${i + 1}`}>
+																{/* Plain img: Next Image optimizer fetches without browser Origin and can 401 against Storage */}
+																<img
+																	src={image}
+																	alt={`Report image ${i + 1}`}
+																	className="h-auto w-full object-cover"
+																	onError={() => markImageBroken(i)}
+																/>
+															</button>
+														)}
+													</div>
+												))}
 											</div>
 										) : (
 											<Typography variant="small" className="italic" color="gray">
@@ -552,6 +629,65 @@ const ReportModal = ({
 					closeModal={setShareReportModal}
 				/>
 			)}
+
+			{activeLightboxImage &&
+				typeof document !== 'undefined' &&
+				createPortal(
+					<div
+						className="fixed inset-0 z-[10001] flex items-center justify-center bg-black/80 p-4"
+						onClick={() => setLightboxIndex(null)}
+						role="dialog"
+						aria-modal="true"
+						aria-label={`Report image ${lightboxIndex + 1}`}>
+						<button
+							type="button"
+							onClick={() => setLightboxIndex(null)}
+							className="absolute right-4 top-4 rounded-full p-1 text-white transition-colors hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white"
+							aria-label="Close image preview">
+							<IoClose className="h-7 w-7" aria-hidden="true" />
+						</button>
+
+						{reportImages.length > 1 && (
+							<>
+								<button
+									type="button"
+									onClick={showPrevLightbox}
+									className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full p-2 text-white transition-colors hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white"
+									aria-label="Previous image">
+									<IoChevronBackOutline className="h-7 w-7" aria-hidden="true" />
+								</button>
+								<button
+									type="button"
+									onClick={showNextLightbox}
+									className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full p-2 text-white transition-colors hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white"
+									aria-label="Next image">
+									<IoChevronForwardOutline className="h-7 w-7" aria-hidden="true" />
+								</button>
+							</>
+						)}
+
+						{lightboxImageBroken ? (
+							<p className="rounded-md bg-white/10 px-4 py-3 text-sm italic text-white/90">
+								Image not found
+							</p>
+						) : (
+							<img
+								src={activeLightboxImage}
+								alt={`Report image ${lightboxIndex + 1}`}
+								className="max-h-[90vh] max-w-full object-contain"
+								onClick={(event) => event.stopPropagation()}
+								onError={() => markImageBroken(lightboxIndex)}
+							/>
+						)}
+
+						{reportImages.length > 1 && (
+							<p className="absolute bottom-4 left-1/2 -translate-x-1/2 text-sm text-white/90">
+								{lightboxIndex + 1} / {reportImages.length}
+							</p>
+						)}
+					</div>,
+					document.body,
+				)}
 		</>
 	)
 }

--- a/components/modals/reports/ReportModal.jsx
+++ b/components/modals/reports/ReportModal.jsx
@@ -253,7 +253,7 @@ const ReportModal = ({
 				</DialogHeader>
 				<DialogBody className="dialog-body overflow-y-auto max-h-[calc(100dvh-8rem)] pt-2">
 					<form onSubmit={onFormSubmit}>
-						<div className='grid md:grid-cols-2 md:gap-10 lg:gap-15'>
+						<div className='grid md:grid-cols-2 md:gap-10 lg:gap-15 md:items-start'>
 							{/* Left Column - Report Content */}
 							<div className='left-side'>
 								<>
@@ -317,7 +317,7 @@ const ReportModal = ({
 							{/* END left side */}
 							
 							{/* Right Column - Metadata and Actions */}
-							<div className='right-side flex flex-col justify-between'>
+							<div className='right-side flex flex-col'>
 								<div>
 									<List className="p-0 mb-5">
 										<ReportMetaItem
@@ -392,13 +392,13 @@ const ReportModal = ({
 									</List>
 
 									{/* Image Gallery */}
-									<div className='images mb-12'>
+									<div className={`images ${report.images?.length > 0 ? 'mb-12' : 'mb-4'}`}>
 										<Typography variant="h5" color="blue" className="mt-0 mb-4">
 											Images
 										</Typography>
-										<div className='grid grid-cols-4 gap-4 w-full overflow-y-auto'>
-											{report.images ?
-												report.images.map((image, i) => {
+										{report.images?.length > 0 ? (
+											<div className='grid grid-cols-4 gap-4 w-full overflow-y-auto'>
+												{report.images.map((image, i) => {
 													return (
 														<div className='grid-cols-subgrid' key={i}>
 															{image ? (
@@ -418,10 +418,13 @@ const ReportModal = ({
 															)}
 														</div>
 													)
-												}) :
-												`No images uploaded`
-											}
-										</div>
+												})}
+											</div>
+										) : (
+											<Typography variant="small" className="italic" color="gray">
+												No images for this report
+											</Typography>
+										)}
 									</div>
 								</div>
 							</div>

--- a/components/reports/ReportSteps/ReviewStep.jsx
+++ b/components/reports/ReportSteps/ReviewStep.jsx
@@ -11,11 +11,9 @@
  */
 
 import React from 'react'
-import { Typography, Card, Button } from '@material-tailwind/react'
+import { Typography, Button } from '@material-tailwind/react'
 import { useTranslation } from 'next-i18next'
 import globalStyles from '../../../styles/globalStyles'
-import Image from 'next/image'
-import Link from 'next/link'
 
 /**
  * ReviewStep Component
@@ -58,19 +56,21 @@ const ReviewStep = ({
   const renderImages = () => {
     if (reportData.images && reportData.images.length > 0) {
       return (
-        <div className="flex w-full overflow-y-auto gap-2">
+        <div className="flex max-w-full min-w-0 flex-wrap gap-2">
           {reportData.images.map((image, index) => (
-            <div key={index} className="flex-shrink-0">
-              <Link href={image} target="_blank">
-                <Image
-                  src={image}
-                  width={100}
-                  height={100}
-                  alt={`Uploaded image ${index + 1}`}
-                  className="object-cover rounded"
-                />
-              </Link>
-            </div>
+            <a
+              key={`${image}-${index}`}
+              href={image}
+              target="_blank"
+              rel="noreferrer"
+              className="shrink-0">
+              {/* Plain img: next/image optimizer can 401 Firebase Storage URLs */}
+              <img
+                src={image}
+                alt={`Uploaded image ${index + 1}`}
+                className="h-[100px] w-[100px] rounded object-cover"
+              />
+            </a>
           ))}
         </div>
       )

--- a/components/reports/ReportSteps/ReviewStep.jsx
+++ b/components/reports/ReportSteps/ReviewStep.jsx
@@ -14,6 +14,7 @@ import React from 'react'
 import { Typography, Button } from '@material-tailwind/react'
 import { useTranslation } from 'next-i18next'
 import globalStyles from '../../../styles/globalStyles'
+import ImageLightboxGallery from '../../ui/ImageLightboxGallery'
 
 /**
  * ReviewStep Component
@@ -56,23 +57,12 @@ const ReviewStep = ({
   const renderImages = () => {
     if (reportData.images && reportData.images.length > 0) {
       return (
-        <div className="flex max-w-full min-w-0 flex-wrap gap-2">
-          {reportData.images.map((image, index) => (
-            <a
-              key={`${image}-${index}`}
-              href={image}
-              target="_blank"
-              rel="noreferrer"
-              className="shrink-0">
-              {/* Plain img: next/image optimizer can 401 Firebase Storage URLs */}
-              <img
-                src={image}
-                alt={`Uploaded image ${index + 1}`}
-                className="h-[100px] w-[100px] rounded object-cover"
-              />
-            </a>
-          ))}
-        </div>
+        <ImageLightboxGallery
+          images={reportData.images}
+          altPrefix="Uploaded image"
+          listClassName="flex max-w-full min-w-0 flex-wrap gap-2"
+          thumbnailClassName="h-[100px] w-[100px] rounded object-cover"
+        />
       )
     } else {
       return <Typography>{t("noImages")}</Typography>

--- a/components/reports/ReportSystem.jsx
+++ b/components/reports/ReportSystem.jsx
@@ -483,16 +483,21 @@ const ReportSystem = ({
 
 	/**
 	 * Handles image upload to Firebase Storage
+	 * @returns {Promise<string[]>} Download URLs (empty if nothing to upload)
 	 */
 	const handleUpload = async () => {
 		if (images.length === 0) {
-			return // No images to upload
+			return []
 		}
 
-		const uploadPromises = images.map((image) => {
+		const stamp = Date.now()
+		const uploadPromises = images.map((image, index) => {
+			// Include index so parallel uploads in the same ms never share a Storage path
+			const safeName =
+				(image?.name || 'image').replace(/[^a-zA-Z0-9._-]/g, '_') || 'image'
 			const storageRef = ref(
 				storage,
-				`reports/${user.accountId}_${new Date().getTime().toString()}.png`
+				`reports/${user.accountId}_${stamp}_${index}_${safeName}`,
 			)
 			const uploadTask = uploadBytesResumable(storageRef, image)
 			return new Promise((resolve, reject) => {
@@ -509,12 +514,9 @@ const ReportSystem = ({
 			})
 		})
 
-		try {
-			const urls = await Promise.all(uploadPromises)
-			setImageURLs(urls)
-		} catch (error) {
-			console.error("Error uploading images:", error)
-		}
+		const urls = await Promise.all(uploadPromises)
+		setImageURLs(urls)
+		return urls
 	}
 
 	/**
@@ -555,9 +557,18 @@ const ReportSystem = ({
 			return
 		}
 
-		// Upload images if any are selected
+		// Upload images if any are selected; keep URLs in state before leaving this step
 		if (images.length > 0) {
-			await handleUpload()
+			try {
+				await handleUpload()
+			} catch (error) {
+				console.error("Error uploading images:", error)
+				setErrors((prev) => ({
+					...prev,
+					images: "Failed to upload images. Please try again.",
+				}))
+				return
+			}
 		}
 
 		// Move to review step

--- a/components/reports/ReportView.jsx
+++ b/components/reports/ReportView.jsx
@@ -12,13 +12,13 @@
  * @requires next-i18next
  */
 
-import React,{ useState,useEffect,useRef } from 'react'
+import React,{ useState,useEffect } from 'react'
 import { IoMdArrowRoundBack } from 'react-icons/io'
 import { doc, onSnapshot } from "firebase/firestore"
 import { db } from '../../config/firebase'
-import Image from 'next/image'
 import {  useTranslation } from 'next-i18next'
 import { formatCityState } from '../../utils/format-location'
+import ImageLightboxGallery from '../ui/ImageLightboxGallery'
 
 /**
  * ReportView Component
@@ -53,11 +53,6 @@ const ReportView = ({ reportView,setReportView,reportSystem,setReportSystem,repo
 	 * @type {Array} data - Report data fetched from Firestore
 	 */
 	const [data,setData] = useState([])
-	
-	/**
-	 * @type {Object} imageErrors - Object tracking image loading errors by index
-	 */
-	const [imageErrors, setImageErrors] = useState({});
 	
 	/**
 	 * Translation hook for internationalization
@@ -104,20 +99,6 @@ const ReportView = ({ reportView,setReportView,reportSystem,setReportSystem,repo
 	useEffect(() => {
 		getData()
 	},[])
-  
-  /**
-   * Handles image loading errors by updating the imageErrors state
-   * 
-   * @function handleImageError
-   * @param {number} index - Index of the image that failed to load
-   * 
-   * @example
-   * // Called when an image fails to load
-   * handleImageError(0)
-   */
-  const handleImageError = (index) => {
-    setImageErrors((prevErrors) => ({ ...prevErrors, [index]: true }));
-  };
 
 	// //
 	// Styles
@@ -171,36 +152,19 @@ const ReportView = ({ reportView,setReportView,reportSystem,setReportSystem,repo
 				</div>
 				
 				{/* Report Images Section */}
-				{data['images'] && data['images'][0] ?
+				{data['images'] && data['images'][0] ? (
 					<div className={style.inputSingle}>
-						<div className='grid grid-cols-4 gap-4'>
-							<div className='col-span-full'>
-								<div className={style.sectionH2}>
-									{t('image_text')}
-								</div>
-							</div>
-							 {data.images.map((image, i) => {
-                return (
-                  <div className="grid-cols-subgrid" key={i}>
-                    {imageErrors[i] ? (
-                      <div className="text-red-500">{t('imageError')}</div>
-                    ) : (
-                      <Image
-                        src={image}
-                        alt="image"
-                        width={200}
-                        height={200}
-                        className="object-cover w-auto"
-                        onError={() => handleImageError(i)}
-                      />
-                    )}
-                  </div>
-                );
-              })}
-						</div>
-					</div> :
+						<div className={style.sectionH2}>{t('image_text')}</div>
+						<ImageLightboxGallery
+							images={data.images}
+							altPrefix="Report image"
+							listClassName="grid grid-cols-4 gap-4 w-full"
+							thumbnailClassName="h-auto w-full object-cover"
+						/>
+					</div>
+				) : (
 					<div className={style.inputSingle}>{t('noImages')}</div>
-				}
+				)}
 				
 				{/* Report Details Section */}
 				<div className={style.inputSingle}>

--- a/components/ui/ImageLightboxGallery.jsx
+++ b/components/ui/ImageLightboxGallery.jsx
@@ -1,0 +1,192 @@
+import React, { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import {
+	IoChevronBackOutline,
+	IoChevronForwardOutline,
+	IoClose,
+} from 'react-icons/io5'
+
+/**
+ * Clickable image thumbnails with a full-screen lightbox (prev/next, Esc).
+ * Uses plain <img> so Firebase Storage download URLs are not blocked by next/image.
+ *
+ * @param {Object} props
+ * @param {string[]} props.images - Image URLs
+ * @param {string} [props.altPrefix='Image'] - Prefix for alt / aria labels
+ * @param {string} [props.listClassName] - Wrapper for the thumbnail list
+ * @param {string} [props.thumbnailClassName] - Classes on each thumbnail img
+ * @param {string} [props.brokenLabel='Image not found'] - Fallback when an img fails
+ * @param {(open: boolean) => void} [props.onLightboxChange] - Notifies parent when lightbox opens/closes
+ */
+const ImageLightboxGallery = ({
+	images = [],
+	altPrefix = 'Image',
+	listClassName = 'grid grid-cols-4 gap-4 w-full overflow-y-auto',
+	thumbnailClassName = 'h-auto w-full object-cover',
+	brokenLabel = 'Image not found',
+	onLightboxChange,
+}) => {
+	const [lightboxIndex, setLightboxIndex] = useState(null)
+	const [brokenImageIndexes, setBrokenImageIndexes] = useState(() => new Set())
+
+	const reportImages = Array.isArray(images) ? images.filter(Boolean) : []
+	const lightboxOpen = lightboxIndex !== null
+	const activeLightboxImage = lightboxOpen ? reportImages[lightboxIndex] : null
+	const lightboxImageBroken =
+		lightboxOpen && brokenImageIndexes.has(lightboxIndex)
+
+	const imagesKey = reportImages.join('|')
+
+	useEffect(() => {
+		setBrokenImageIndexes(new Set())
+		setLightboxIndex(null)
+	}, [imagesKey])
+
+	useEffect(() => {
+		onLightboxChange?.(lightboxOpen)
+	}, [lightboxOpen, onLightboxChange])
+
+	useEffect(() => {
+		if (!lightboxOpen) return undefined
+		if (lightboxIndex >= reportImages.length) {
+			setLightboxIndex(reportImages.length > 0 ? reportImages.length - 1 : null)
+			return undefined
+		}
+
+		const onKeyDown = (event) => {
+			if (event.key === 'Escape') {
+				setLightboxIndex(null)
+				return
+			}
+			if (reportImages.length <= 1) return
+			if (event.key === 'ArrowLeft') {
+				setLightboxIndex(
+					(current) =>
+						((current ?? 0) - 1 + reportImages.length) % reportImages.length,
+				)
+			}
+			if (event.key === 'ArrowRight') {
+				setLightboxIndex(
+					(current) => ((current ?? 0) + 1) % reportImages.length,
+				)
+			}
+		}
+
+		document.addEventListener('keydown', onKeyDown)
+		return () => document.removeEventListener('keydown', onKeyDown)
+	}, [lightboxOpen, lightboxIndex, reportImages.length])
+
+	if (reportImages.length === 0) return null
+
+	const markImageBroken = (index) => {
+		setBrokenImageIndexes((prev) => {
+			if (prev.has(index)) return prev
+			const next = new Set(prev)
+			next.add(index)
+			return next
+		})
+	}
+
+	const showPrevLightbox = (event) => {
+		event.stopPropagation()
+		setLightboxIndex(
+			(current) =>
+				((current ?? 0) - 1 + reportImages.length) % reportImages.length,
+		)
+	}
+
+	const showNextLightbox = (event) => {
+		event.stopPropagation()
+		setLightboxIndex((current) => ((current ?? 0) + 1) % reportImages.length)
+	}
+
+	return (
+		<>
+			<div className={listClassName}>
+				{reportImages.map((image, i) => (
+					<div className="grid-cols-subgrid shrink-0" key={`${image}-${i}`}>
+						{brokenImageIndexes.has(i) ? (
+							<span className="flex min-h-[4.5rem] items-center justify-center rounded-md border border-slate-200 bg-slate-50 px-2 text-center text-xs italic text-gray-400">
+								{brokenLabel}
+							</span>
+						) : (
+							<button
+								type="button"
+								onClick={() => setLightboxIndex(i)}
+								className="block w-full overflow-hidden rounded-md border border-slate-200 bg-white transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+								aria-label={`View ${altPrefix.toLowerCase()} ${i + 1}`}>
+								<img
+									src={image}
+									alt={`${altPrefix} ${i + 1}`}
+									className={thumbnailClassName}
+									onError={() => markImageBroken(i)}
+								/>
+							</button>
+						)}
+					</div>
+				))}
+			</div>
+
+			{activeLightboxImage &&
+				typeof document !== 'undefined' &&
+				createPortal(
+					<div
+						className="fixed inset-0 z-[10001] flex items-center justify-center bg-black/80 p-4"
+						onClick={() => setLightboxIndex(null)}
+						role="dialog"
+						aria-modal="true"
+						aria-label={`${altPrefix} ${lightboxIndex + 1}`}>
+						<button
+							type="button"
+							onClick={() => setLightboxIndex(null)}
+							className="absolute right-4 top-4 rounded-full p-1 text-white transition-colors hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white"
+							aria-label="Close image preview">
+							<IoClose className="h-7 w-7" aria-hidden="true" />
+						</button>
+
+						{reportImages.length > 1 && (
+							<>
+								<button
+									type="button"
+									onClick={showPrevLightbox}
+									className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full p-2 text-white transition-colors hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white"
+									aria-label="Previous image">
+									<IoChevronBackOutline className="h-7 w-7" aria-hidden="true" />
+								</button>
+								<button
+									type="button"
+									onClick={showNextLightbox}
+									className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full p-2 text-white transition-colors hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white"
+									aria-label="Next image">
+									<IoChevronForwardOutline className="h-7 w-7" aria-hidden="true" />
+								</button>
+							</>
+						)}
+
+						{lightboxImageBroken ? (
+							<p className="rounded-md bg-white/10 px-4 py-3 text-sm italic text-white/90">
+								{brokenLabel}
+							</p>
+						) : (
+							<img
+								src={activeLightboxImage}
+								alt={`${altPrefix} ${lightboxIndex + 1}`}
+								className="max-h-[90vh] max-w-full object-contain"
+								onClick={(event) => event.stopPropagation()}
+								onError={() => markImageBroken(lightboxIndex)}
+							/>
+						)}
+
+						{reportImages.length > 1 && (
+							<p className="absolute bottom-4 left-1/2 -translate-x-1/2 text-sm text-white/90">
+								{lightboxIndex + 1} / {reportImages.length}
+							</p>
+						)}
+					</div>,
+					document.body,
+				)}
+		</>
+	)
+}
+
+export default ImageLightboxGallery

--- a/components/ui/MediaUploadField.jsx
+++ b/components/ui/MediaUploadField.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import {
 	IoChevronBackOutline,
 	IoChevronForwardOutline,
@@ -37,25 +37,29 @@ const MediaUploadField = ({
 }) => {
 	const [isDragging, setIsDragging] = useState(false)
 	const [lightboxIndex, setLightboxIndex] = useState(null)
+	const [previews, setPreviews] = useState([])
 	const localInputRef = useRef(null)
 	const ref = inputRef || localInputRef
 
-	const previews = useMemo(
-		() =>
-			files.map((file, index) => ({
-				index,
-				key: `${file.name}-${file.size}-${file.lastModified}-${index}`,
-				url: URL.createObjectURL(file),
-				name: file.name,
-			})),
-		[files],
-	)
-
+	// Create blob URLs in an effect (not useMemo). Strict Mode remounts revoke
+	// memoized URLs while keeping the same memo result → broken <img> srcs.
 	useEffect(() => {
+		const next = files.map((file, index) => ({
+			index,
+			key: `${file?.name || 'file'}-${file?.size || 0}-${file?.lastModified || 0}-${index}`,
+			url:
+				typeof Blob !== 'undefined' && file instanceof Blob
+					? URL.createObjectURL(file)
+					: String(file || ''),
+			name: file?.name || `image-${index + 1}`,
+		}))
+		setPreviews(next)
 		return () => {
-			previews.forEach((preview) => URL.revokeObjectURL(preview.url))
+			next.forEach((preview) => {
+				if (preview.url?.startsWith('blob:')) URL.revokeObjectURL(preview.url)
+			})
 		}
-	}, [previews])
+	}, [files])
 
 	useEffect(() => {
 		if (lightboxIndex === null) return undefined

--- a/pages/report.jsx
+++ b/pages/report.jsx
@@ -73,7 +73,6 @@ const Report = () => {
 	}
 
 	const handleReportSystemPrevStep = () => {
-		
 			if (reminderShow == false && reportSystem <= 2) {
 				setReportSystem(reportSystem == 0)         
 			} else{

--- a/storage.rules
+++ b/storage.rules
@@ -3,11 +3,10 @@ rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
     match /{allPaths=**} {
-      // Allow read access for everyone (unauthenticated) during development
-      allow read: if request.auth == null && request.origin == "http://localhost:3000";
-      
-      // Restrict write access to authenticated users
-      allow write, read: if request.auth != null;
+      // Authenticated app users can read/write.
+      // Download URLs from getDownloadURL() also work via their token (public link).
+      // Note: request.origin is not a valid Storage rules field — do not use it.
+      allow read, write: if request.auth != null;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replace report image open-in-new-tab / `next/image` with a shared `ImageLightboxGallery` (thumbnails → full-screen preview, arrows, Esc, broken-image fallback) in `ReportModal`, public `ReviewStep`, and `ReportView` history.
- Fix Firebase Storage image loads: plain `<img>` (avoids optimizer 401s), unique Storage upload paths, upload errors surfaced before review, and Storage rules cleaned up (`request.origin` removed).
- Quiet Material Tailwind Dialog `aria-hidden` console noise by delaying `Dialog` `open` one tick after mount.

## Test plan
- [ ] Dashboard: open a report with images → thumbnails open lightbox; arrows / Esc / backdrop close work; Esc doesn’t close the report modal while lightbox is open
- [ ] Public `/report` flow: upload images → review step thumbnails open the same lightbox
- [ ] Report history (`ReportView`): thumbnails open lightbox; broken URLs show “Image not found”
- [ ] Submit a new report with multiple images; confirm all URLs save and display
- [ ] Confirm opening the report modal no longer floods the console with `aria-hidden … Doing nothing`