### PR TITLE
Design/admin users view

### DIFF
--- a/components/admin/Agencies.jsx
+++ b/components/admin/Agencies.jsx
@@ -343,7 +343,10 @@ const Agencies = ({handleAgencyUpdateSubmit}) => {
 
 				try {
 					// Send sign-in invitation to new user
-					await sendSignIn(userEmail)
+					await sendSignIn(userEmail, {
+						agencyId,
+						agencyName: agencyInfo?.name,
+					})
 					setSendEmail(`Sign-in link sent to ${userEmail}`)
 				} catch (error) {
 					console.error(`Error sending sign-in link to ${userEmail}:`, error)
@@ -384,7 +387,10 @@ const Agencies = ({handleAgencyUpdateSubmit}) => {
 	 * @returns {Promise<void>} Promise that resolves when email is sent
 	 */
 	const sendAgencyLinks = async (email) => {
-		await sendSignIn(email)
+		await sendSignIn(email, {
+			agencyId,
+			agencyName: agencyInfo?.name,
+		})
 		setResendEmail('Email was sent.')
 	}
 
@@ -519,7 +525,11 @@ const Agencies = ({handleAgencyUpdateSubmit}) => {
 
 		// Send passwordless invite links first so failures surface and we do not
 		// create an agency row without a working invite path.
-		await Promise.all(normalizedEmails.map((email) => sendSignIn(email)))
+		await Promise.all(
+			normalizedEmails.map((email) =>
+				sendSignIn(email, { agencyName: name }),
+			),
+		)
 
 		const agencyPayload = {
 			name,

--- a/components/admin/Appearance.jsx
+++ b/components/admin/Appearance.jsx
@@ -92,7 +92,7 @@ const Appearance = () => {
 				Configure shared dashboard colors. Changes apply for all signed-in users.
 			</p>
 
-			<div className="mb-8 p-6 bg-white rounded-lg border border-blue-gray-100">
+			<div className="mb-8 p-6 bg-white rounded-md border border-blue-gray-100">
 				<Typography variant="h5" color="blue" className="mb-4">
 					Report table
 				</Typography>

--- a/components/admin/ExperimentSettings.jsx
+++ b/components/admin/ExperimentSettings.jsx
@@ -231,14 +231,14 @@ const ExperimentSettings = () => {
 
 	if (!config) {
 		return (
-			<div data-component="ExperimentSettings" className="mb-8 p-4 bg-white rounded-lg">
+			<div data-component="ExperimentSettings" className="mb-8 p-4 bg-white rounded-md">
 				<Typography>Loading experiment settings…</Typography>
 			</div>
 		)
 	}
 
 	return (
-		<div data-component="ExperimentSettings" className="experiment-settings mb-8 p-6 bg-white rounded-lg border border-blue-gray-100">
+		<div data-component="ExperimentSettings" className="experiment-settings mb-8 p-6 bg-white rounded-md border border-blue-gray-100">
 			<Typography variant="h5" color="blue" className="mb-4">
 				Experiment &amp; archive
 			</Typography>

--- a/components/admin/Settings.jsx
+++ b/components/admin/Settings.jsx
@@ -179,15 +179,15 @@ const Settings = () => {
       {tagSystem == 0 ?
       <div className="z-0 flex-col p-16">
         {customClaims.admin && <TagDefaultsSettings />}
-        <div className="mb-8 p-6 bg-white rounded-lg border border-blue-gray-100">
+        <div className="mb-8 p-6 bg-white rounded-md border border-blue-gray-100">
           <div className={globalStyles.heading.h1.blue}>Tagging Systems</div>
           {agencyClaimsStatus === 'pending' && (
-            <div className="mb-4 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800">
+            <div className="mb-4 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800">
               Loading agency access…
             </div>
           )}
           {agencyClaimsStatus === 'missing' && (
-            <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+            <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
               Agency access is incomplete (missing agency ID on your account).
               Refresh the page, or ask an admin to re-run agency claims backfill.
             </div>

--- a/components/admin/TagDefaultsSettings.jsx
+++ b/components/admin/TagDefaultsSettings.jsx
@@ -163,7 +163,7 @@ function RequiredTagListEditor({ title, maxActive, tags, setTags }) {
 						return (
 							<li
 								key={tag.id}
-								className="rounded-lg bg-blue-gray-50 p-3">
+								className="rounded-md bg-blue-gray-50 p-3">
 								<form
 									onSubmit={commitEdit}
 									className="flex flex-col gap-2">
@@ -242,7 +242,7 @@ function RequiredTagListEditor({ title, maxActive, tags, setTags }) {
 					return (
 						<li
 							key={tag.id}
-							className="flex items-start justify-between gap-2 rounded-lg bg-blue-gray-50 px-3 py-2 text-sm">
+							className="flex items-start justify-between gap-2 rounded-md bg-blue-gray-50 px-3 py-2 text-sm">
 							<div>
 								<div className="font-medium">
 									{tag.labels.en}
@@ -420,14 +420,14 @@ const TagDefaultsSettings = () => {
 
 	if (loading) {
 		return (
-			<div data-component="TagDefaultsSettings" className="mb-8 p-6 bg-white rounded-lg border border-blue-gray-100">
+			<div data-component="TagDefaultsSettings" className="mb-8 p-6 bg-white rounded-md border border-blue-gray-100">
 				<Typography>Loading global tag defaults…</Typography>
 			</div>
 		)
 	}
 
 	return (
-		<div data-component="TagDefaultsSettings" className="mb-8 p-6 bg-white rounded-lg border border-blue-gray-100">
+		<div data-component="TagDefaultsSettings" className="mb-8 p-6 bg-white rounded-md border border-blue-gray-100">
 			<div className={globalStyles.heading.h1.blue}>Global Tag Defaults</div>
 			<p className="text-sm text-gray-600 mb-4">
 				These Topic and Source tags are required for every newsroom. Agencies

--- a/components/admin/Users.jsx
+++ b/components/admin/Users.jsx
@@ -61,7 +61,7 @@ import ConfirmModal from '../modals/common/ConfirmModal'
 import EditUserModal from '../modals/admin/EditUserModal'
 import NewUserModal from '../modals/admin/NewUserModal'
 import { FaPlus } from 'react-icons/fa'
-import { HiChevronDown, HiChevronUp } from 'react-icons/hi2'
+import { HiChevronDown, HiChevronUp, HiMagnifyingGlass } from 'react-icons/hi2'
 import {
 	Card,
 	CardHeader,
@@ -1509,6 +1509,7 @@ const Users = () => {
 								label="Search"
 								value={searchTerm}
 								onChange={(e) => setSearchTerm(e.target.value)}
+								icon={<HiMagnifyingGlass className="h-5 w-5" />}
 							/>
 						</div>
 					</div>

--- a/components/admin/Users.jsx
+++ b/components/admin/Users.jsx
@@ -1555,7 +1555,7 @@ const Users = () => {
 				</CardHeader>
 
 				{paginationError && (
-					<div className="mx-4 mb-2 flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-red-700">
+					<div className="mx-4 mb-2 flex items-center gap-2 rounded-md border border-red-200 bg-red-50 p-3 text-red-700">
 						<Typography variant="small" className="font-bold">
 							Error:
 						</Typography>
@@ -1563,12 +1563,12 @@ const Users = () => {
 					</div>
 				)}
 				{agencyClaimsStatus === 'pending' && (
-					<div className="mx-4 mb-2 flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 p-3 text-blue-800">
+					<div className="mx-4 mb-2 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 p-3 text-blue-800">
 						<Typography variant="small">Loading agency access…</Typography>
 					</div>
 				)}
 				{agencyClaimsStatus === 'missing' && (
-					<div className="mx-4 mb-2 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-900">
+					<div className="mx-4 mb-2 flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-900">
 						<Typography variant="small">
 							Agency access is incomplete (missing agency ID on your account).
 							Refresh the page, or ask an admin to re-run agency claims
@@ -1850,7 +1850,7 @@ const Users = () => {
 							</table>
 						</InfiniteScroll>
 					</CardBody>
-					<CardFooter className="flex shrink-0 flex-wrap items-center gap-2 rounded-b-xl border-t border-blue-gray-50 bg-blue-gray-50/80 p-4">
+					<CardFooter className="flex shrink-0 flex-wrap items-center gap-2 rounded-b-md border-t border-blue-gray-50 bg-blue-gray-50/80 p-4">
 						{!customClaims.agency && (
 							<div className="flex flex-wrap items-center gap-2">
 								<Typography variant="small" className="font-bold">

--- a/components/admin/Users.jsx
+++ b/components/admin/Users.jsx
@@ -151,6 +151,48 @@ const patchUserRowInList = (prev, docId, partial) => {
 }
 
 /**
+ * Maps agency membership emails → display names.
+ * Org association lives on `agency.agencyUsers`, not on `mobileUsers`.
+ *
+ * @param {Array<{ name?: string, agencyUsers?: string[] }>} agencies
+ * @returns {Map<string, string>} lowercase email → agency name
+ */
+const buildEmailToAgencyNameMap = (agencies) => {
+	const map = new Map()
+	for (const agency of agencies || []) {
+		const name = typeof agency?.name === 'string' ? agency.name.trim() : ''
+		if (!name) continue
+		for (const raw of agency.agencyUsers || []) {
+			if (typeof raw !== 'string') continue
+			const email = raw.trim().toLowerCase()
+			if (email) map.set(email, name)
+		}
+	}
+	return map
+}
+
+/**
+ * Attaches `agencyName` onto user rows via email membership lookup.
+ *
+ * @param {Array<Object>} users
+ * @param {Map<string, string>} emailToAgencyName
+ * @param {boolean} [agenciesLoaded=false] - When true, clear names for emails not in any agency
+ * @returns {Array<Object>}
+ */
+const withAgencyNames = (users, emailToAgencyName, agenciesLoaded = false) => {
+	if (!users?.length) return users
+	if (!agenciesLoaded) return users
+	return users.map((user) => {
+		const email =
+			typeof user?.email === 'string' ? user.email.trim().toLowerCase() : ''
+		const fromMembership = email ? emailToAgencyName.get(email) : undefined
+		const nextName = fromMembership || ''
+		if ((user.agencyName ?? '') === nextName) return user
+		return { ...user, agencyName: nextName }
+	})
+}
+
+/**
  * Sort by Firestore `joiningDate` (seconds), falling back to parsed `joined` string.
  * Returns a new array (does not mutate the input).
  *
@@ -515,6 +557,12 @@ const Users = () => {
 		}
 	}, [authGetUserList])
 
+	/** Email → agency display name from membership lists (for Agency column). */
+	const emailToAgencyName = useMemo(
+		() => buildEmailToAgencyNameMap(agenciesArray),
+		[agenciesArray],
+	)
+
 	// Processed users: combines pagination data with auth details and applies search.
 	// Ordered by joiningDate per Join Date header toggle (default newest-first).
 	const loadedMobileUsers = useMemo(() => {
@@ -537,7 +585,14 @@ const Users = () => {
 					: baseUsers
 		}
 
-		return sortByJoinedDate(list, joinDateSort)
+		return sortByJoinedDate(
+			withAgencyNames(
+				list,
+				emailToAgencyName,
+				!!customClaims?.admin && agenciesArray.length > 0,
+			),
+			joinDateSort,
+		)
 	}, [
 		paginatedUsers,
 		agencyUsers,
@@ -548,6 +603,8 @@ const Users = () => {
 		searchActive,
 		remoteSearchHits,
 		joinDateSort,
+		emailToAgencyName,
+		agenciesArray.length,
 	])
 
 	/**
@@ -637,11 +694,11 @@ const Users = () => {
 	 */
 	const fetchAgencies = async () => {
 		const snapshot = await getDocs(collection(db, 'agency'))
-		const agencies = snapshot.docs.map((doc) => ({
-			id: doc.id,
-			name: doc.data().name,
+		const agencies = snapshot.docs.map((docSnap) => ({
+			id: docSnap.id,
+			name: docSnap.data().name,
+			agencyUsers: docSnap.data().agencyUsers || [],
 		}))
-		// console.log(agencies);
 		setAgenciesArray(agencies)
 	}
 
@@ -875,62 +932,35 @@ const Users = () => {
 	}
 
 	/**
-	 * Handles the submission of the form to add a new user.
-	 *
-	 * This function is responsible for managing the entire process of adding a new user.
-	 * It first prevents the default form submission behavior and clears any existing errors.
-	 * The function then validates the new user's email address to ensure it meets the minimum
-	 * length requirement (at least 15 characters). If the email is valid, the function attempts
-	 * to send a sign-in link to the provided email address.
-	 *
-	 * After successfully sending the sign-in link, the function adds the new user's email to the
-	 * `agencyUsers` array in the corresponding Firestore agency document, provided that the
-	 * `agencyId` is valid. If any part of this process fails, the error is caught and handled by
-	 * updating the `errors` state with the appropriate message.
-	 *
-	 * Finally, if all operations succeed, the function triggers a state update to refresh the user list
-	 * and closes the modal.
+	 * Invites a public (non-admin, non-agency) user via passwordless email link.
+	 * They complete signup on /signup and are created as a regular User.
 	 *
 	 * @param {Event} e - The event object from the form submission.
-	 * @returns {Promise<void>} A promise that resolves after the sign-in email is sent, the user's email
-	 * is added to the Firestore agency document, and the modal is closed. If an error is encountered,
-	 * it is handled and displayed in the form.
+	 * @returns {Promise<void>}
 	 */
 	const handleAddNewUserFormSubmit = async (e) => {
 		e.preventDefault()
 		try {
-			// Clear previous errors
 			setErrors({})
 
-			// Validate the email length before sending the sign-in link
-			if (newUserEmail.length < 15) {
+			const trimmedEmail = newUserEmail.trim()
+			const emailOk = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)
+			if (!emailOk) {
 				setErrors((prevErrors) => ({
 					...prevErrors,
-					// Error message shown to user
-					email: 'Email should be at least 15 characters long',
+					email: 'Enter a valid email address',
 				}))
-				return // Stop the form submission if there's a validation error
+				return
 			}
 
-			await sendSignIn(newUserEmail)
+			await sendSignIn(trimmedEmail)
 
-			// Add the new user's email to the agency's `agencyUsers` array in Firestore
-			// Validate agencyId before proceeding
-			if (!agencyId || agencyId.trim() === '') {
-				throw new Error('Invalid or missing agency ID')
-			}
-			const agencyRef = doc(db, 'agency', agencyId)
-			console.log(agencyRef)
-			await updateDoc(agencyRef, {
-				agencyUsers: arrayUnion(newUserEmail),
-			})
-
+			setNewUserEmail('')
 			setUpdate(!update)
 			setNewUserModal(false)
 		} catch (error) {
 			console.error('Error in handleAddNewUserFormSubmit:', error.message)
 
-			// Set the error message in the errors state
 			setErrors((prevErrors) => ({
 				...prevErrors,
 				email: error.message,
@@ -1210,6 +1240,8 @@ const Users = () => {
 							)
 						}
 					}
+					setAgencyName(selectedAgency.name || '')
+					await fetchAgencies()
 				} else {
 				}
 			} catch (error) {
@@ -1428,12 +1460,22 @@ const Users = () => {
 			}
 		}
 
+		const resolvedAgencyName =
+			userRole === 'Agency'
+				? agenciesArray.find((a) => a.id === selectedAgency)?.name ||
+					agencyName ||
+					''
+				: ''
 		const optimisticPatch = {
 			...serializedAdditionalFields,
 			name,
 			email,
 			isBanned: banned,
 			userRole,
+			agencyName: resolvedAgencyName,
+		}
+		if (customClaims.admin) {
+			await fetchAgencies()
 		}
 		if (customClaims.agency) {
 			setAgencyUsers((prev) => patchUserRowInList(prev, userId, optimisticPatch))
@@ -1470,21 +1512,18 @@ const Users = () => {
 	return (
 		<div data-component="Users" className={style.section_container}>
 			<Card className="h-full w-full">
-				<CardHeader floated={false} shadow={false} className="rounded-none">
+				<CardHeader floated={false} shadow={false} data-element="users-card-header" className="mb-4">
 					<div className="mb-4 flex flex-col justify-between gap-4 md:flex-row md:items-center">
 						<div>
-							<Typography variant="h5" color="blue-gray">
+							<Typography variant="h2" color="blue-gray" className="mt-0">
 								Users
-							</Typography>
-							<Typography color="gray" className="mt-1 font-normal">
-								{customClaims.admin ? 'Admin: All Users' : 'All Agency'}
 							</Typography>
 						</div>
 						<Button
 							className="flex items-center gap-3"
 							size="sm"
 							onClick={handleAddNewUserModal}>
-							<FaPlus className="h-3.5 w-3.5" /> Add User
+							<FaPlus className="h-3.5 w-3.5" /> Invite User
 						</Button>
 					</div>
 					<div className="flex flex-col items-center justify-between gap-4 md:flex-row">
@@ -1537,30 +1576,6 @@ const Users = () => {
 						</Typography>
 					</div>
 				)}
-				{!customClaims.agency && (
-					<div className="mx-4 mb-2 flex flex-wrap items-center gap-2 rounded-lg bg-white p-2">
-						<Typography variant="small" className="font-bold">
-							Key:
-						</Typography>
-						<div className="flex items-center gap-1">
-							<Typography variant="small" className="bg-red-50 p-1">
-								Red:
-							</Typography>
-							<Typography variant="small">
-								Firestore &apos;mobileUsers&apos; doc missing
-							</Typography>
-						</div>
-						<div className="flex items-center gap-1">
-							<Typography variant="small" className="bg-yellow-100 p-1">
-								Yellow:
-							</Typography>
-							<Typography variant="small">
-								User disabled in Firebase Auth
-							</Typography>
-						</div>
-					</div>
-				)}
-
 				<div
 					ref={tableHostRef}
 					className="flex min-h-0 flex-col"
@@ -1835,11 +1850,36 @@ const Users = () => {
 							</table>
 						</InfiniteScroll>
 					</CardBody>
-					<CardFooter className="flex shrink-0 items-center justify-end border-t border-blue-gray-50 p-4">
+					<CardFooter className="flex shrink-0 flex-wrap items-center gap-2 rounded-b-xl border-t border-blue-gray-50 bg-blue-gray-50/80 p-4">
+						{!customClaims.agency && (
+							<div className="flex flex-wrap items-center gap-2">
+								<Typography variant="small" className="font-bold">
+									Key:
+								</Typography>
+								<div className="flex items-center gap-1">
+									<Typography variant="small" className="bg-red-50 p-1">
+										Red:
+									</Typography>
+									<Typography variant="small">
+										Firestore &apos;mobileUsers&apos; doc missing
+									</Typography>
+								</div>
+								<div className="flex items-center gap-1">
+									<Typography
+										variant="small"
+										className="bg-yellow-100 p-1">
+										Yellow:
+									</Typography>
+									<Typography variant="small">
+										User disabled in Firebase Auth
+									</Typography>
+								</div>
+							</div>
+						)}
 						<Typography
 							variant="small"
 							color="blue-gray"
-							className="font-normal">
+							className="ml-auto font-normal">
 							Total users: {loadedMobileUsers.length}
 						</Typography>
 					</CardFooter>

--- a/components/admin/Users.jsx
+++ b/components/admin/Users.jsx
@@ -71,6 +71,9 @@ import {
 	Button,
 	IconButton,
 	Tooltip,
+	Tabs,
+	TabsHeader,
+	Tab,
 } from '@material-tailwind/react'
 import { useUsersPagination } from '../../hooks/useUsersPagination'
 import { searchUsers, findMobileUsersByEmail } from '../../utils/firebase-helpers'
@@ -94,6 +97,14 @@ const tableTd = 'whitespace-normal p-4'
 const tableTdCenter =
 	'whitespace-normal md:whitespace-nowrap p-4 text-center'
 const style = adminSectionStyles
+
+/** Admin role filter tabs — values match Firestore `userRole` / EditUserModal. */
+const ROLE_TABS = [
+	{ label: 'All', value: 'all' },
+	{ label: 'Admin', value: 'Admin' },
+	{ label: 'Agency', value: 'Agency' },
+	{ label: 'User', value: 'User' },
+]
 
 /**
  * Retrieves the user's join date based on available data.
@@ -1463,20 +1474,36 @@ const Users = () => {
 								{customClaims.admin ? 'Admin: All Users' : 'All Agency'}
 							</Typography>
 						</div>
-						<div className="flex w-full shrink-0 flex-col gap-2 sm:flex-row sm:items-center md:w-max">
-							<div className="w-full md:w-72">
-								<Input
-									label="Search"
-									value={searchTerm}
-									onChange={(e) => setSearchTerm(e.target.value)}
-								/>
-							</div>
-							<Button
-								className="flex items-center gap-3"
-								size="sm"
-								onClick={handleAddNewUserModal}>
-								<FaPlus className="h-3.5 w-3.5" /> Add User
-							</Button>
+						<Button
+							className="flex items-center gap-3"
+							size="sm"
+							onClick={handleAddNewUserModal}>
+							<FaPlus className="h-3.5 w-3.5" /> Add User
+						</Button>
+					</div>
+					<div className="flex flex-col items-center justify-between gap-4 md:flex-row">
+						{customClaims.admin ? (
+							<Tabs value={roleFilter} className="w-full md:w-max">
+								<TabsHeader>
+									{ROLE_TABS.map(({ label, value }) => (
+										<Tab
+											key={value}
+											value={value}
+											onClick={() => setRoleFilter(value)}>
+											&nbsp;&nbsp;{label}&nbsp;&nbsp;
+										</Tab>
+									))}
+								</TabsHeader>
+							</Tabs>
+						) : (
+							<div className="hidden md:block" />
+						)}
+						<div className="w-full md:w-72">
+							<Input
+								label="Search"
+								value={searchTerm}
+								onChange={(e) => setSearchTerm(e.target.value)}
+							/>
 						</div>
 					</div>
 				</CardHeader>

--- a/components/admin/Users.jsx
+++ b/components/admin/Users.jsx
@@ -61,6 +61,7 @@ import ConfirmModal from '../modals/common/ConfirmModal'
 import EditUserModal from '../modals/admin/EditUserModal'
 import NewUserModal from '../modals/admin/NewUserModal'
 import { FaPlus } from 'react-icons/fa'
+import { HiChevronDown, HiChevronUp } from 'react-icons/hi2'
 import {
 	Card,
 	CardHeader,
@@ -91,7 +92,7 @@ const dateOptions = {
 	month: 'short',
 }
 const tableTh =
-	'sticky top-0 z-10 border-y border-blue-gray-100 bg-blue-gray-50/50 p-4'
+	'sticky top-0 z-10 border-y border-blue-gray-100 bg-blue-gray-50/80 p-4'
 const tableThCenter = `${tableTh} text-center`
 const tableTd = 'whitespace-normal p-4'
 const tableTdCenter =
@@ -150,17 +151,23 @@ const patchUserRowInList = (prev, docId, partial) => {
 }
 
 /**
- * Sorts an array of users by their join date in descending order.
+ * Sort by Firestore `joiningDate` (seconds), falling back to parsed `joined` string.
+ * Returns a new array (does not mutate the input).
  *
- * This function takes an array of user objects and sorts them based on their `joined` date.
- * The sorting is done in descending order, so users with the most recent join date will appear first.
- * The `joined` date is expected to be a string that can be converted into a Date object.
- *
- * @param {Array<Object>} users - An array of user objects, each containing a `joined` date field.
- * @returns {Array<Object>} The sorted array of users, with the most recently joined users first.
+ * @param {Array<Object>} users
+ * @param {'asc' | 'desc'} [direction='desc'] - `desc` = newest first, `asc` = oldest first
+ * @returns {Array<Object>}
  */
-const sortByJoinedDate = (users) => {
-	return users.sort((a, b) => new Date(b.joined) - new Date(a.joined))
+const sortByJoinedDate = (users, direction = 'desc') => {
+	const joinTs = (user) => {
+		const raw = user?.joiningDate
+		if (typeof raw === 'number' && Number.isFinite(raw)) return raw
+		if (raw && typeof raw.seconds === 'number') return raw.seconds
+		const parsed = user?.joined ? Date.parse(user.joined) : NaN
+		return Number.isFinite(parsed) ? parsed / 1000 : 0
+	}
+	const dir = direction === 'asc' ? 1 : -1
+	return [...(users || [])].sort((a, b) => (joinTs(a) - joinTs(b)) * dir)
 }
 
 const describeFirestoreField = (fieldValue) => {
@@ -383,6 +390,9 @@ const Users = () => {
 	const [userRole, setUserRole] = useState('') // Current user's role being edited
 	const [searchTerm, setSearchTerm] = useState('') // Search term for filtering users
 	const [roleFilter, setRoleFilter] = useState('all') // Role filter for users
+	const [joinDateSort, setJoinDateSort] = useState(
+		/** @type {'asc' | 'desc'} */ ('desc'),
+	) // Join Date column sort; default newest-first
 	const [deleteModal, setDeleteModal] = useState(false) // Delete confirmation modal
 	const [userEditing, setUserEditing] = useState([]) // User data being edited
 	const [name, setName] = useState('') // User name being edited
@@ -505,30 +515,29 @@ const Users = () => {
 		}
 	}, [authGetUserList])
 
-	// Processed users: combines pagination data with auth details and applies search
+	// Processed users: combines pagination data with auth details and applies search.
+	// Ordered by joiningDate per Join Date header toggle (default newest-first).
 	const loadedMobileUsers = useMemo(() => {
+		let list
 		if (emailSearchActive) {
-			if (remoteSearchHits !== null) {
-				return remoteSearchHits
-			}
-			return []
+			list = remoteSearchHits !== null ? remoteSearchHits : []
+		} else {
+			const usedEnhanced =
+				!!customClaims?.admin &&
+				enhancedPaginatedUsers.length === paginatedUsers.length
+			const baseUsers = customClaims?.agency
+				? agencyUsers
+				: usedEnhanced
+					? enhancedPaginatedUsers
+					: paginatedUsers
+
+			list =
+				searchActive && !emailSearchActive
+					? searchUsers(baseUsers, searchTerm)
+					: baseUsers
 		}
 
-		const usedEnhanced =
-			!!customClaims?.admin &&
-			enhancedPaginatedUsers.length === paginatedUsers.length
-		const baseUsers = customClaims?.agency
-			? agencyUsers
-			: usedEnhanced
-				? enhancedPaginatedUsers
-				: paginatedUsers
-
-		// Name (non-email) search: filter already-loaded rows only
-		if (searchActive && !emailSearchActive) {
-			return searchUsers(baseUsers, searchTerm)
-		}
-
-		return baseUsers
+		return sortByJoinedDate(list, joinDateSort)
 	}, [
 		paginatedUsers,
 		agencyUsers,
@@ -538,6 +547,7 @@ const Users = () => {
 		emailSearchActive,
 		searchActive,
 		remoteSearchHits,
+		joinDateSort,
 	])
 
 	/**
@@ -1586,6 +1596,39 @@ const Users = () => {
 							<table className="w-full min-w-max table-auto text-left">
 								<thead>
 									<tr>
+										<th
+											scope="col"
+											className={`${tableTh} cursor-pointer transition-colors hover:bg-blue-gray-100`}
+											onClick={() =>
+												setJoinDateSort((prev) =>
+													prev === 'desc' ? 'asc' : 'desc',
+												)
+											}
+											aria-sort={
+												joinDateSort === 'asc'
+													? 'ascending'
+													: 'descending'
+											}>
+											<Typography
+												variant="small"
+												color="blue-gray"
+												className="flex items-center gap-1 font-normal leading-none opacity-70">
+												Join Date
+												{joinDateSort === 'asc' ? (
+													<HiChevronUp
+														strokeWidth={1}
+														className="h-3.5 w-3.5"
+														aria-hidden
+													/>
+												) : (
+													<HiChevronDown
+														strokeWidth={1}
+														className="h-3.5 w-3.5"
+														aria-hidden
+													/>
+												)}
+											</Typography>
+										</th>
 										<th scope="col" className={tableTh}>
 											<Typography
 												variant="small"
@@ -1600,14 +1643,6 @@ const Users = () => {
 												color="blue-gray"
 												className="font-normal leading-none opacity-70">
 												Email
-											</Typography>
-										</th>
-										<th scope="col" className={tableThCenter}>
-											<Typography
-												variant="small"
-												color="blue-gray"
-												className="font-normal leading-none opacity-70">
-												Join Date
 											</Typography>
 										</th>
 										{customClaims.admin && (
@@ -1722,7 +1757,15 @@ const Users = () => {
 															variant="small"
 															color="blue-gray"
 															className="font-normal">
-															{userObj.name}
+															{userObj.joined ?? 'No Date'}
+														</Typography>
+													</td>
+													<td className={cellClass}>
+														<Typography
+															variant="small"
+															color="blue-gray"
+															className="font-normal">
+															{userObj.name ?? ''}
 														</Typography>
 													</td>
 													<td className={cellClassCenter}>
@@ -1730,15 +1773,7 @@ const Users = () => {
 															variant="small"
 															color="blue-gray"
 															className="font-normal">
-															{userObj.email}
-														</Typography>
-													</td>
-													<td className={cellClassCenter}>
-														<Typography
-															variant="small"
-															color="blue-gray"
-															className="font-normal">
-															{userObj.joined}
+															{userObj.email ?? ''}
 														</Typography>
 													</td>
 													{customClaims.admin && (
@@ -1747,7 +1782,7 @@ const Users = () => {
 																variant="small"
 																color="blue-gray"
 																className="font-normal">
-																{userObj.agencyName}
+																{userObj.agencyName ?? ''}
 															</Typography>
 														</td>
 													)}
@@ -1757,7 +1792,7 @@ const Users = () => {
 																variant="small"
 																color="blue-gray"
 																className="font-normal">
-																{userObj.userRole}
+																{userObj.userRole ?? ''}
 															</Typography>
 														</td>
 													)}

--- a/components/admin/Users.jsx
+++ b/components/admin/Users.jsx
@@ -55,14 +55,23 @@ import {
 	GeoPoint,
 } from 'firebase/firestore'
 import { db, auth } from '../../config/firebase'
-import { Tooltip } from 'react-tooltip'
 import { IoTrash } from 'react-icons/io5'
 import InfiniteScroll from 'react-infinite-scroll-component'
 import ConfirmModal from '../modals/common/ConfirmModal'
 import EditUserModal from '../modals/admin/EditUserModal'
 import NewUserModal from '../modals/admin/NewUserModal'
 import { FaPlus } from 'react-icons/fa'
-import globalStyles from '../../styles/globalStyles'
+import {
+	Card,
+	CardHeader,
+	CardBody,
+	CardFooter,
+	Typography,
+	Input,
+	Button,
+	IconButton,
+	Tooltip,
+} from '@material-tailwind/react'
 import { useUsersPagination } from '../../hooks/useUsersPagination'
 import { searchUsers, findMobileUsersByEmail } from '../../utils/firebase-helpers'
 import {
@@ -78,16 +87,12 @@ const dateOptions = {
 	year: 'numeric',
 	month: 'short',
 }
-const tableHeading = {
-	default: 'px-3 py-1 text-sm font-semibold text-left tracking-wide',
-	default_center: 'text-center p-2 text-sm font-semibold tracking-wide',
-	small: '',
-}
-const column = {
-	data: 'whitespace-normal text-sm px-3 py-1',
-	data_center:
-		'whitespace-normal md:whitespace-nowrap text-sm px-3 py-1 text-center',
-}
+const tableTh =
+	'sticky top-0 z-10 border-y border-blue-gray-100 bg-blue-gray-50/50 p-4'
+const tableThCenter = `${tableTh} text-center`
+const tableTd = 'whitespace-normal p-4'
+const tableTdCenter =
+	'whitespace-normal md:whitespace-nowrap p-4 text-center'
 const style = adminSectionStyles
 
 /**
@@ -440,7 +445,7 @@ const Users = () => {
 
 	/** White table panel: fill down to 20px above the viewport bottom. */
 	const TABLE_VIEWPORT_BOTTOM_GAP = 20
-	const TABLE_FOOTER_RESERVE = 28
+	const TABLE_FOOTER_RESERVE = 64
 	const tableHostRef = useRef(/** @type {HTMLDivElement | null} */ (null))
 	const [tableHostHeight, setTableHostHeight] = useState(560)
 
@@ -1447,69 +1452,86 @@ const Users = () => {
 
 	return (
 		<div data-component="Users" className={style.section_container}>
-			<div className={style.section_wrapper}>
-				<div className={style.section_header}>
-					<div className={style.section_title}>
-						<div className={`${globalStyles.heading.h1.blue} leading-none`}>
-							Users
+			<Card className="h-full w-full">
+				<CardHeader floated={false} shadow={false} className="rounded-none">
+					<div className="mb-4 flex flex-col justify-between gap-4 md:flex-row md:items-center">
+						<div>
+							<Typography variant="h5" color="blue-gray">
+								Users
+							</Typography>
+							<Typography color="gray" className="mt-1 font-normal">
+								{customClaims.admin ? 'Admin: All Users' : 'All Agency'}
+							</Typography>
 						</div>
-						{customClaims.admin ? (
-							<span className="text-xs">Admin: All Users</span>
-						) : (
-							<span className="text-xs">All Agency</span>
-						)}
+						<div className="flex w-full shrink-0 flex-col gap-2 sm:flex-row sm:items-center md:w-max">
+							<div className="w-full md:w-72">
+								<Input
+									label="Search"
+									value={searchTerm}
+									onChange={(e) => setSearchTerm(e.target.value)}
+								/>
+							</div>
+							<Button
+								className="flex items-center gap-3"
+								size="sm"
+								onClick={handleAddNewUserModal}>
+								<FaPlus className="h-3.5 w-3.5" /> Add User
+							</Button>
+						</div>
 					</div>
-					<div className={style.section_filtersWrap}>
-						<input
-							type="text"
-							placeholder="Search users by name or email..."
-							value={searchTerm}
-							onChange={(e) => setSearchTerm(e.target.value)}
-							className="px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm mr-2"
-						/>
-						<button className={style.button} onClick={handleAddNewUserModal}>
-							<FaPlus className="text-[#2E3B4E] mr-2" size={12} />
-							Add User
-						</button>
-					</div>
-				</div>
-				{/* Error message for pagination issues */}
+				</CardHeader>
+
 				{paginationError && (
-					<div className="flex items-center gap-2 p-3 bg-red-50 border border-red-200 rounded-lg text-sm mb-2 text-red-700">
-						<div className="font-bold">Error:</div>
-						<div>{paginationError}</div>
+					<div className="mx-4 mb-2 flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-red-700">
+						<Typography variant="small" className="font-bold">
+							Error:
+						</Typography>
+						<Typography variant="small">{paginationError}</Typography>
 					</div>
 				)}
 				{agencyClaimsStatus === 'pending' && (
-					<div className="flex items-center gap-2 p-3 bg-blue-50 border border-blue-200 rounded-lg text-sm mb-2 text-blue-800">
-						Loading agency access…
+					<div className="mx-4 mb-2 flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 p-3 text-blue-800">
+						<Typography variant="small">Loading agency access…</Typography>
 					</div>
 				)}
 				{agencyClaimsStatus === 'missing' && (
-					<div className="flex items-center gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm mb-2 text-amber-900">
-						Agency access is incomplete (missing agency ID on your account).
-						Refresh the page, or ask an admin to re-run agency claims backfill.
+					<div className="mx-4 mb-2 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-900">
+						<Typography variant="small">
+							Agency access is incomplete (missing agency ID on your account).
+							Refresh the page, or ask an admin to re-run agency claims
+							backfill.
+						</Typography>
 					</div>
 				)}
-				{/* Data status legend for admins - shows data consistency issues */}
 				{!customClaims.agency && (
-					<div className="flex items-center gap-2 p-2 bg-white rounded-lg text-xs mb-2">
-						<div className="font-bold">Key: </div>
-						<div className="flex gap-1 items-center">
-							<div className="bg-red-50 p-1">Red:</div>
-							<div>Firestore 'mobileUsers' doc missing</div>
+					<div className="mx-4 mb-2 flex flex-wrap items-center gap-2 rounded-lg bg-white p-2">
+						<Typography variant="small" className="font-bold">
+							Key:
+						</Typography>
+						<div className="flex items-center gap-1">
+							<Typography variant="small" className="bg-red-50 p-1">
+								Red:
+							</Typography>
+							<Typography variant="small">
+								Firestore &apos;mobileUsers&apos; doc missing
+							</Typography>
 						</div>
-						<div className="flex gap-1 items-center">
-							<div className="bg-yellow-100 p-1">Yellow:</div>
-							<div>User disabled in Firebase Auth</div>
+						<div className="flex items-center gap-1">
+							<Typography variant="small" className="bg-yellow-100 p-1">
+								Yellow:
+							</Typography>
+							<Typography variant="small">
+								User disabled in Firebase Auth
+							</Typography>
 						</div>
 					</div>
 				)}
+
 				<div
 					ref={tableHostRef}
-					className={style.table_main}
+					className="flex min-h-0 flex-col"
 					style={{ height: tableHostHeight }}>
-					<div className="flex flex-col h-full min-h-0">
+					<CardBody className="flex-1 overflow-hidden px-0 py-0">
 						<InfiniteScroll
 							className="overflow-x-auto"
 							height={Math.max(
@@ -1525,149 +1547,225 @@ const Users = () => {
 								hasMore && !customClaims.agency && !searchActive
 							}
 							loader={
-								<div className="text-center py-4">
-									<span className="text-gray-500">Loading more users...</span>
+								<div className="py-4 text-center">
+									<Typography
+										variant="small"
+										color="blue-gray"
+										className="font-normal opacity-70">
+										Loading more users...
+									</Typography>
 								</div>
 							}>
-							<table className="min-w-full bg-white rounded-md p-1 border-separate border-spacing-0">
-								<thead className="border-b dark:border-indigo-100">
+							<table className="w-full min-w-max table-auto text-left">
+								<thead>
 									<tr>
-										<th
-											scope="col"
-											className={`${tableHeading.default} sticky top-0 z-10 bg-slate-100`}>
-											Name
+										<th scope="col" className={tableTh}>
+											<Typography
+												variant="small"
+												color="blue-gray"
+												className="font-normal leading-none opacity-70">
+												Name
+											</Typography>
 										</th>
-										<th
-											scope="col"
-											className={`${tableHeading.default_center} sticky top-0 z-10 bg-slate-100`}>
-											Email
+										<th scope="col" className={tableThCenter}>
+											<Typography
+												variant="small"
+												color="blue-gray"
+												className="font-normal leading-none opacity-70">
+												Email
+											</Typography>
 										</th>
-										<th
-											scope="col"
-											className={`${tableHeading.default_center} sticky top-0 z-10 bg-slate-100`}>
-											Join Date
+										<th scope="col" className={tableThCenter}>
+											<Typography
+												variant="small"
+												color="blue-gray"
+												className="font-normal leading-none opacity-70">
+												Join Date
+											</Typography>
 										</th>
 										{customClaims.admin && (
-											<th
-												scope="col"
-												className={`${tableHeading.default_center} sticky top-0 z-10 bg-slate-100`}>
-												Agency
+											<th scope="col" className={tableThCenter}>
+												<Typography
+													variant="small"
+													color="blue-gray"
+													className="font-normal leading-none opacity-70">
+													Agency
+												</Typography>
 											</th>
 										)}
 										{customClaims.admin && (
-											<th
-												scope="col"
-												className={`${tableHeading.default_center} sticky top-0 z-10 bg-slate-100`}>
-												Role
+											<th scope="col" className={tableThCenter}>
+												<Typography
+													variant="small"
+													color="blue-gray"
+													className="font-normal leading-none opacity-70">
+													Role
+												</Typography>
 											</th>
 										)}
-										<th
-											scope="col"
-											className={`${tableHeading.default_center} sticky top-0 z-10 bg-slate-100`}>
-											Banned
+										<th scope="col" className={tableThCenter}>
+											<Typography
+												variant="small"
+												color="blue-gray"
+												className="font-normal leading-none opacity-70">
+												Banned
+											</Typography>
 										</th>
-										<th
-											scope="col"
-											className={`${tableHeading.default_center} sticky top-0 z-10 bg-slate-100`}>
-											Disabled
+										<th scope="col" className={tableThCenter}>
+											<Typography
+												variant="small"
+												color="blue-gray"
+												className="font-normal leading-none opacity-70">
+												Disabled
+											</Typography>
 										</th>
 										{customClaims.admin && (
 											<th
 												scope="col"
 												colSpan={2}
-												className={`${tableHeading.default_center} sticky top-0 z-10 bg-slate-100`}>
-												Delete
+												className={tableThCenter}>
+												<Typography
+													variant="small"
+													color="blue-gray"
+													className="font-normal leading-none opacity-70">
+													Delete
+												</Typography>
 											</th>
 										)}
 									</tr>
 								</thead>
 								<tbody>
-									{/* Loading state - shows spinner while fetching user data */}
 									{initialLoading ||
 									(isLoading && loadedMobileUsers.length === 0) ||
 									agencyLoading ||
 									remoteSearchLoading ? (
 										<tr>
 											<td colSpan="100%" className="text-center">
-												<div className="flex flex-col justify-center items-center gap-2 h-40">
+												<div className="flex h-40 flex-col items-center justify-center gap-2">
 													<LoadingSpinner className="h-10 w-10 text-[#2E3B4E]" />
-													<span className="text-sm text-gray-600">Loading users…</span>
+													<Typography
+														variant="small"
+														color="blue-gray"
+														className="font-normal">
+														Loading users…
+													</Typography>
 												</div>
 											</td>
 										</tr>
 									) : loadedMobileUsers.length === 0 ? (
 										<tr>
 											<td colSpan="100%" className="text-center">
-												<div className="flex justify-center items-center h-32">
-													No users found
+												<div className="flex h-32 items-center justify-center">
+													<Typography
+														variant="small"
+														color="blue-gray"
+														className="font-normal">
+														No users found
+													</Typography>
 												</div>
 											</td>
 										</tr>
 									) : (
-										// Render user rows with role-based conditional rendering
 										loadedMobileUsers.map((userObj, index) => {
-											// Extract user ID for operations
-											let userId = userObj.mobileUserId ?? userObj.id ?? userObj.uid
+											let userId =
+												userObj.mobileUserId ?? userObj.id ?? userObj.uid
+											const isLast =
+												index === loadedMobileUsers.length - 1
+											const cellClass = isLast
+												? tableTd
+												: `${tableTd} border-b border-blue-gray-50`
+											const cellClassCenter = isLast
+												? tableTdCenter
+												: `${tableTdCenter} border-b border-blue-gray-50`
 											return (
 												<tr
-													className={`border-b transition duration-300 ease-in-out dark:border-indigo-100 ${!customClaims.agency && !userObj.hasFirestoreDoc && 'bg-red-50'} ${userObj.disabled && 'bg-yellow-100'}`}
-													key={userId ?? userObj.email ?? `unknown-${index}`}
+													className={`transition duration-300 ease-in-out ${!customClaims.agency && !userObj.hasFirestoreDoc && 'bg-red-50'} ${userObj.disabled && 'bg-yellow-100'} ${customClaims.admin ? 'cursor-pointer hover:bg-blue-gray-50/50' : ''}`}
+													key={
+														userId ??
+														userObj.email ??
+														`unknown-${index}`
+													}
 													onClick={
 														customClaims.admin
 															? () => handleEditUser(userObj, userId)
 															: undefined
 													}>
-													{/* User name column */}
-													<td scope="row" className={column.data}>
-														{userObj.name}
+													<td scope="row" className={cellClass}>
+														<Typography
+															variant="small"
+															color="blue-gray"
+															className="font-normal">
+															{userObj.name}
+														</Typography>
 													</td>
-													{/* User email column */}
-													<td className={column.data_center}>
-														{userObj.email}
+													<td className={cellClassCenter}>
+														<Typography
+															variant="small"
+															color="blue-gray"
+															className="font-normal">
+															{userObj.email}
+														</Typography>
 													</td>
-													{/* User join date column */}
-													<td className={column.data_center}>
-														{userObj.joined}
+													<td className={cellClassCenter}>
+														<Typography
+															variant="small"
+															color="blue-gray"
+															className="font-normal">
+															{userObj.joined}
+														</Typography>
 													</td>
-													{/* Agency column - only visible to admins */}
 													{customClaims.admin && (
-														<td className={column.data_center}>
-															{userObj.agencyName}
+														<td className={cellClassCenter}>
+															<Typography
+																variant="small"
+																color="blue-gray"
+																className="font-normal">
+																{userObj.agencyName}
+															</Typography>
 														</td>
 													)}
-													{/* User role column - only visible to admins */}
 													{customClaims.admin && (
-														<td className={column.data_center}>
-															{userObj.userRole}
+														<td className={cellClassCenter}>
+															<Typography
+																variant="small"
+																color="blue-gray"
+																className="font-normal">
+																{userObj.userRole}
+															</Typography>
 														</td>
 													)}
-													{/* User banned status column */}
-													<td className={column.data_center}>
-														{(userObj.isBanned && 'yes') || 'no'}
+													<td className={cellClassCenter}>
+														<Typography
+															variant="small"
+															color="blue-gray"
+															className="font-normal">
+															{(userObj.isBanned && 'yes') || 'no'}
+														</Typography>
 													</td>
-													{/* User disabled status column */}
-													<td className={column.data_center}>
-														{userObj.disabled ? 'Yes' : 'No'}
+													<td className={cellClassCenter}>
+														<Typography
+															variant="small"
+															color="blue-gray"
+															className="font-normal">
+															{userObj.disabled ? 'Yes' : 'No'}
+														</Typography>
 													</td>
-													{/* Delete action column - only visible to admins */}
 													{customClaims.admin && (
 														<td
-															className={column.data_center}
+															className={cellClassCenter}
 															onClick={(e) => e.stopPropagation()}>
-															<button
-																onClick={() => handleMobileUserDelete(userId)}
-																className={`${style.table_button} tooltip-delete-user`}>
-																<IoTrash
-																	size={20}
-																	className="ml-4 fill-gray-400 hover:fill-red-600"
-																/>
-																<Tooltip
-																	anchorSelect=".tooltip-delete-user"
-																	place="top"
-																	delayShow={500}>
-																	Delete User
-																</Tooltip>
-															</button>
+															<Tooltip content="Delete User">
+																<IconButton
+																	variant="text"
+																	onClick={() =>
+																		handleMobileUserDelete(userId)
+																	}>
+																	<IoTrash
+																		size={20}
+																		className="fill-gray-400 hover:fill-red-600"
+																	/>
+																</IconButton>
+															</Tooltip>
 														</td>
 													)}
 												</tr>
@@ -1677,13 +1775,17 @@ const Users = () => {
 								</tbody>
 							</table>
 						</InfiniteScroll>
-						<div className="mt-2 self-end text-xs shrink-0">
+					</CardBody>
+					<CardFooter className="flex shrink-0 items-center justify-end border-t border-blue-gray-50 p-4">
+						<Typography
+							variant="small"
+							color="blue-gray"
+							className="font-normal">
 							Total users: {loadedMobileUsers.length}
-						</div>
-					</div>
+						</Typography>
+					</CardFooter>
 				</div>
-			</div>
-			{/* Delete confirmation modal */}
+			</Card>
 			{deleteModal && (
 				<ConfirmModal
 					func={handleDelete}
@@ -1693,53 +1795,38 @@ const Users = () => {
 					closeModal={setDeleteModal}
 				/>
 			)}
-			{/* User editing modal */}
 			{userEditModal && (
 				<EditUserModal
 					mobileUserDetails={mobileUserDetails}
 					onMobileFieldChange={handleMobileUserFieldChange}
 					mobileUserFieldTypes={mobileUserFieldTypes}
 					mobileFieldFormError={mobileFieldFormError}
-					// User
 					userId={userId}
 					userEditing={userEditing}
-					// Claims
 					customClaims={customClaims}
-					// Modal
 					setUserEditModal={toggleUserEditModal}
-					// Name
 					name={name}
 					onNameChange={handleNameChange}
-					// agency
 					agenciesArray={agenciesArray}
 					selectedAgency={selectedAgency}
 					agencyName={agencyName}
 					onAgencyChange={handleAgencyChange}
-					// Role
 					onRoleChange={handleRoleChange}
 					userRole={userRole}
 					setUserRole={setUserRole}
-					// Email
 					email={email}
 					onEmailChange={handleEmailChange}
-					// Banned
 					banned={banned}
 					setBanned={setBanned}
 					onBannedChange={handleBannedChange}
-					// Form submit
 					onFormSubmit={handleFormSubmit}
 				/>
 			)}
-			{/* New user creation modal */}
 			{newUserModal && (
 				<NewUserModal
 					setNewUserModal={setNewUserModal}
-					// newUserName={newUserName}
-					// onNewUserName={handleNewUserName}
 					newUserEmail={newUserEmail}
 					onNewUserEmail={handleNewUserEmail}
-					// onNewAgencyState={handleNewAgencyState}
-					// onNewAgencyCity={handleNewAgencyCity}
 					onFormSubmit={handleAddNewUserFormSubmit}
 					errors={errors}
 				/>

--- a/components/admin/Users.jsx
+++ b/components/admin/Users.jsx
@@ -1266,8 +1266,14 @@ const Users = () => {
 	 *
 	 * @param {Event} e - The event object from the banned status toggle.
 	 */
-	const handleBannedChange = (e) => {
-		setBanned((prevBanned) => !prevBanned) // Use a function to toggle based on previous state
+	/**
+	 * Syncs banned status from EditUserModal Switch (`checked` boolean).
+	 * Must set the value — toggling cancels the modal's own setBanned(next).
+	 *
+	 * @param {boolean} checked - Next banned state from the Switch
+	 */
+	const handleBannedChange = (checked) => {
+		setBanned(Boolean(checked))
 	}
 
 	/**

--- a/components/admin/Users.jsx
+++ b/components/admin/Users.jsx
@@ -32,6 +32,7 @@
 import React, {
 	useState,
 	useEffect,
+	useLayoutEffect,
 	useContext,
 	useMemo,
 	useCallback,
@@ -436,6 +437,34 @@ const Users = () => {
 	const [remoteSearchLoading, setRemoteSearchLoading] = useState(false)
 	const searchActive = !!(searchTerm && searchTerm.trim())
 	const emailSearchActive = searchActive && searchTerm.includes('@')
+
+	/** White table panel: fill down to 20px above the viewport bottom. */
+	const TABLE_VIEWPORT_BOTTOM_GAP = 20
+	const TABLE_FOOTER_RESERVE = 28
+	const tableHostRef = useRef(/** @type {HTMLDivElement | null} */ (null))
+	const [tableHostHeight, setTableHostHeight] = useState(560)
+
+	useLayoutEffect(() => {
+		const updateTableHeight = () => {
+			const el = tableHostRef.current
+			if (!el) return
+			const top = el.getBoundingClientRect().top
+			const next = Math.floor(
+				window.innerHeight - top - TABLE_VIEWPORT_BOTTOM_GAP,
+			)
+			setTableHostHeight(Math.max(240, next))
+		}
+		updateTableHeight()
+		window.addEventListener('resize', updateTableHeight)
+		return () => window.removeEventListener('resize', updateTableHeight)
+	}, [
+		agencyClaimsStatus,
+		paginationError,
+		customClaims?.agency,
+		customClaims?.admin,
+		searchActive,
+		remoteSearchLoading,
+	])
 
 	const getAuthUsersMap = useCallback(async () => {
 		if (authUsersMapRef.current) {
@@ -1476,11 +1505,17 @@ const Users = () => {
 						</div>
 					</div>
 				)}
-				<div className={style.table_main}>
-					<div className="flex flex-col h-full">
+				<div
+					ref={tableHostRef}
+					className={style.table_main}
+					style={{ height: tableHostHeight }}>
+					<div className="flex flex-col h-full min-h-0">
 						<InfiniteScroll
 							className="overflow-x-auto"
-							height={560}
+							height={Math.max(
+								200,
+								tableHostHeight - TABLE_FOOTER_RESERVE,
+							)}
 							dataLength={loadedMobileUsers.length}
 							next={() => {
 								if (searchActive) return
@@ -1628,7 +1663,7 @@ const Users = () => {
 								</tbody>
 							</table>
 						</InfiniteScroll>
-						<div className="mt-2 self-end text-xs">
+						<div className="mt-2 self-end text-xs shrink-0">
 							Total users: {loadedMobileUsers.length}
 						</div>
 					</div>

--- a/components/admin/Users.jsx
+++ b/components/admin/Users.jsx
@@ -1529,39 +1529,53 @@ const Users = () => {
 									<span className="text-gray-500">Loading more users...</span>
 								</div>
 							}>
-							<table className="min-w-full bg-white rounded-md p-1">
-								<thead className="border-b dark:border-indigo-100 bg-slate-100">
+							<table className="min-w-full bg-white rounded-md p-1 border-separate border-spacing-0">
+								<thead className="border-b dark:border-indigo-100">
 									<tr>
-										<th scope="col" className={tableHeading.default}>
+										<th
+											scope="col"
+											className={`${tableHeading.default} sticky top-0 z-10 bg-slate-100`}>
 											Name
 										</th>
-										<th scope="col" className={tableHeading.default_center}>
+										<th
+											scope="col"
+											className={`${tableHeading.default_center} sticky top-0 z-10 bg-slate-100`}>
 											Email
 										</th>
-										<th scope="col" className={tableHeading.default_center}>
+										<th
+											scope="col"
+											className={`${tableHeading.default_center} sticky top-0 z-10 bg-slate-100`}>
 											Join Date
 										</th>
 										{customClaims.admin && (
-											<th scope="col" className={tableHeading.default_center}>
+											<th
+												scope="col"
+												className={`${tableHeading.default_center} sticky top-0 z-10 bg-slate-100`}>
 												Agency
 											</th>
 										)}
 										{customClaims.admin && (
-											<th scope="col" className={tableHeading.default_center}>
+											<th
+												scope="col"
+												className={`${tableHeading.default_center} sticky top-0 z-10 bg-slate-100`}>
 												Role
 											</th>
 										)}
-										<th scope="col" className={tableHeading.default_center}>
+										<th
+											scope="col"
+											className={`${tableHeading.default_center} sticky top-0 z-10 bg-slate-100`}>
 											Banned
 										</th>
-										<th scope="col" className={tableHeading.default_center}>
+										<th
+											scope="col"
+											className={`${tableHeading.default_center} sticky top-0 z-10 bg-slate-100`}>
 											Disabled
 										</th>
 										{customClaims.admin && (
 											<th
 												scope="col"
 												colSpan={2}
-												className={tableHeading.default_center}>
+												className={`${tableHeading.default_center} sticky top-0 z-10 bg-slate-100`}>
 												Delete
 											</th>
 										)}

--- a/components/admin/Users.jsx
+++ b/components/admin/Users.jsx
@@ -1105,10 +1105,6 @@ const Users = () => {
 		if (userAgencyDoc) {
 			const userAgency = userAgencyDoc.id // Get the document ID
 			const agencyName = userAgencyDoc.data().name // Get the agency name from the document data
-
-			console.log('userAgency ID --> ', userAgency)
-			console.log('agencyName --> ', agencyName)
-
 			setSelectedAgency(userAgency)
 			setAgencyName(agencyName)
 		} else {
@@ -1158,12 +1154,9 @@ const Users = () => {
 		e.preventDefault()
 		const selectedValue = e.target.value
 		setSelectedAgency(selectedValue)
-		// console.log(selectedAgency.name)
 		const selectedAgency = agenciesArray.find(
 			(agency) => agency.id === selectedValue,
 		)
-		// console.log(selectedAgency) // Additional debugging to verify the correct agency is selected
-
 		if (selectedAgency) {
 			try {
 				// Fetch the current data of the agency document to which the user is being added
@@ -1204,9 +1197,7 @@ const Users = () => {
 								claimError,
 							)
 						}
-						console.log('User successfully added to the new agency.')
 					} else {
-						console.log('User already exists in this agency.')
 						try {
 							await addAgencyRole({
 								email,
@@ -1220,7 +1211,6 @@ const Users = () => {
 						}
 					}
 				} else {
-					console.log('Agency document does not exist.')
 				}
 			} catch (error) {
 				console.error('Error updating agency documents:', error)

--- a/components/analytics/ComparisonGraphMenu.jsx
+++ b/components/analytics/ComparisonGraphMenu.jsx
@@ -245,7 +245,7 @@ const ComparisonGraphMenu = ({dateRange, setDateRange,
     </div>
     {showCalendar == 1 &&  
       <>    
-        <div className="absolute z-50 mt-2 right-0 bg-white p-2 rounded-lg shadow-xl border border-gray-200">
+        <div className="absolute z-50 mt-2 right-0 bg-white p-2 rounded-md shadow-xl border border-gray-200">
           <DateRange
             editableDateInputs={true}
             onChange={item => handleDateSelection(item)}

--- a/components/analytics/TagSystem.jsx
+++ b/components/analytics/TagSystem.jsx
@@ -573,8 +573,8 @@ const TagSystem = ({ tagSystem, setTagSystem, agencyID }) => {
 				</form>
 
 				{search.length > 0 && (
-					<div className="shadow-lg absolute rounded-lg z-20 mt-2 w-1/2">
-						<div className="bg-white w-full rounded-lg">
+					<div className="shadow-lg absolute rounded-md z-20 mt-2 w-1/2">
+						<div className="bg-white w-full rounded-md">
 							{searchResult.map((item) => {
 								if (!isLabelsMode && isOtherTagName(item)) return null
 								if (isLabelsMode && isAppWideLabel(item)) return null
@@ -584,7 +584,7 @@ const TagSystem = ({ tagSystem, setTagSystem, agencyID }) => {
 											setSelected(item)
 											setSearchResult([])
 										}}
-										className="text-light text-sm rounded-lg leading-tight py-2 pl-4 hover:bg-indigo-100 cursor-pointer"
+										className="text-light text-sm rounded-md leading-tight py-2 pl-4 hover:bg-indigo-100 cursor-pointer"
 										key={item}>
 										{formatTagDisplay(item, {
 											required: isRequiredTag(item, requiredTags),

--- a/components/common/PwaInstallBanner.jsx
+++ b/components/common/PwaInstallBanner.jsx
@@ -112,7 +112,7 @@ export default function PwaInstallBanner() {
 			role="region"
 			aria-label="Install app"
 		>
-			<div className="pointer-events-auto mx-auto max-w-md rounded-xl bg-[#2E3B4E] text-white shadow-lg ring-1 ring-black/10">
+			<div className="pointer-events-auto mx-auto max-w-md rounded-md bg-[#2E3B4E] text-white shadow-lg ring-1 ring-black/10">
 				<div className="flex items-start gap-3 p-4">
 					<div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-blue-600">
 						<MdInstallMobile size={22} aria-hidden />

--- a/components/layout/Navbar.jsx
+++ b/components/layout/Navbar.jsx
@@ -45,6 +45,17 @@ import ContactHelpModal from '../modals/ContactHelpModal'
 import { useAuth } from '../../context/AuthContext'
 import { useTranslation } from 'next-i18next'
 
+/** Must match `VIEW_BY_TAB` in pages/dashboard.jsx */
+const DASHBOARD_VIEW_BY_TAB = [
+	'home',
+	'profile',
+	'settings',
+	'users',
+	'agencies',
+	'help',
+	'appearance',
+]
+
 /**
  * Navbar - Main navigation sidebar component.
  * 
@@ -81,7 +92,8 @@ const Navbar = ({
 	isOpen,
 }) => {
 	const { t } = useTranslation('Navbar')
-	
+	const router = useRouter()
+
 	// Window size state for responsive behavior
 	const [windowSize, setWindowSize] = useState([
 		window.innerWidth,
@@ -138,10 +150,20 @@ const Navbar = ({
 
 	/**
 	 * Handles navigation to a specific tab.
-	 * 
+	 * On /report, only Profile is local; other tabs live on the dashboard.
+	 *
 	 * @param {number} tabIndex - The tab index to navigate to
 	 */
 	const handleTabNavigation = (tabIndex) => {
+		const onDashboard = router.pathname === '/dashboard'
+
+		if (!onDashboard && tabIndex !== 1) {
+			const view = DASHBOARD_VIEW_BY_TAB[tabIndex] ?? 'home'
+			router.push({ pathname: '/dashboard', query: { view } })
+			closeDrawer()
+			return
+		}
+
 		setTab(tabIndex)
 		closeDrawer()
 	}

--- a/components/modals/ContactHelpModal.jsx
+++ b/components/modals/ContactHelpModal.jsx
@@ -14,6 +14,7 @@ import FormInput from '../ui/FormInput'
 import FormTextarea from '../ui/FormTextarea'
 import MediaUploadField from '../ui/MediaUploadField'
 import ModalCloseButton from '../ui/ModalCloseButton'
+import { useDelayedDialogOpen } from '../../hooks/useDelayedDialogOpen'
 import {
 	Button,
 	Dialog,
@@ -24,6 +25,7 @@ import {
 
 const ContactHelpModal = ({ open, setContactHelpModal }) => {
 	const { t } = useTranslation('Navbar')
+	const dialogOpen = useDelayedDialogOpen(open)
 	const dbInstance = collection(db, 'helpRequests')
 	const { user } = useAuth()
 	const storage = getStorage()
@@ -141,7 +143,7 @@ const ContactHelpModal = ({ open, setContactHelpModal }) => {
 
 	return (
 		<Dialog data-component="ContactHelpModal"
-			open={open}
+			open={dialogOpen}
 			handler={handleClose}
 			size="lg"
 			className="contact-help-modal rounded-md">

--- a/components/modals/HelpRequestsModal.jsx
+++ b/components/modals/HelpRequestsModal.jsx
@@ -10,16 +10,20 @@ import Image from 'next/image'
 import Link from 'next/link'
 import React, { Fragment } from 'react'
 import ModalCloseButton from '../ui/ModalCloseButton'
+import { useDelayedDialogOpen } from '../../hooks/useDelayedDialogOpen'
 
 const formatLabel = (label) => label.replace(/([a-z])([A-Z])/g, '$1 $2')
 
 /**
- * Mount when visible; Dialog is always open while mounted.
+ * Mount when visible; Dialog opens one tick later to avoid Floating UI
+ * aria-hidden warnings when mounting with open={true} immediately.
  */
 const HelpRequestsModal = ({ helpRequestInfo, handleClose, mailtoLink }) => {
+	const dialogOpen = useDelayedDialogOpen()
+
 	return (
 		<Dialog data-component="HelpRequestsModal"
-			open
+			open={dialogOpen}
 			handler={handleClose}
 			size="lg"
 			className="help-requests-modal rounded-md">

--- a/components/modals/LocationModal.jsx
+++ b/components/modals/LocationModal.jsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'next-i18next'
 import { State, City } from 'country-state-city'
 import FormSelect from '../ui/FormSelect'
 import ModalCloseButton from '../ui/ModalCloseButton'
+import { useDelayedDialogOpen } from '../../hooks/useDelayedDialogOpen'
 import {
 	Button,
 	Dialog,
@@ -15,14 +16,15 @@ import {
 } from '@material-tailwind/react'
 
 /**
- * Mount when visible (`{locationModal && <LocationModal ... />}`); Dialog is always open
- * while mounted, matching existing call sites.
+ * Mount when visible (`{locationModal && <LocationModal ... />}`); Dialog opens
+ * one tick later to avoid Floating UI aria-hidden warnings.
  */
 const LocationModal = ({ setLocationModal }) => {
 	const { t } = useTranslation('Profile')
 	const { user } = useAuth()
 	const [userLocation, setUserLocation] = useState(null)
 	const [errors, setErrors] = useState({})
+	const dialogOpen = useDelayedDialogOpen()
 
 	const handleClose = () => setLocationModal(false)
 
@@ -55,7 +57,7 @@ const LocationModal = ({ setLocationModal }) => {
 
 	return (
 		<Dialog data-component="LocationModal"
-			open
+			open={dialogOpen}
 			handler={handleClose}
 			size="xs"
 			className="location-modal rounded-md"

--- a/components/modals/ThankYouModal.jsx
+++ b/components/modals/ThankYouModal.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ModalCloseButton from '../ui/ModalCloseButton'
+import { useDelayedDialogOpen } from '../../hooks/useDelayedDialogOpen'
 import {
 	Dialog,
 	DialogBody,
@@ -8,10 +9,13 @@ import {
 } from '@material-tailwind/react'
 
 /**
- * Mount when visible; Dialog is always open while mounted.
- * Closes contact-help flow via setContactHelpModal / setContactSent when provided.
+ * Mount when visible; Dialog opens one tick later to avoid Floating UI
+ * aria-hidden warnings. Closes contact-help flow via setContactHelpModal /
+ * setContactSent when provided.
  */
 const ThankYouModal = ({ setContactHelpModal, setContactSent }) => {
+	const dialogOpen = useDelayedDialogOpen()
+
 	const handleClose = () => {
 		setContactHelpModal?.(false)
 		setContactSent?.(false)
@@ -19,7 +23,7 @@ const ThankYouModal = ({ setContactHelpModal, setContactSent }) => {
 
 	return (
 		<Dialog data-component="ThankYouModal"
-			open
+			open={dialogOpen}
 			handler={handleClose}
 			size="xs"
 			className="thank-you-modal rounded-md">

--- a/components/modals/admin/AgencyModal.jsx
+++ b/components/modals/admin/AgencyModal.jsx
@@ -5,6 +5,7 @@ import ConfirmModal from '../common/ConfirmModal'
 import FormInput from '../../ui/FormInput'
 import MediaUploadField from '../../ui/MediaUploadField'
 import ModalCloseButton from '../../ui/ModalCloseButton'
+import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
 import {
 	Button,
 	Dialog,
@@ -15,7 +16,8 @@ import {
 } from '@material-tailwind/react'
 
 /**
- * Mount when visible; Dialog is always open while mounted.
+ * Mount when visible; Dialog opens one tick later to avoid Floating UI
+ * aria-hidden warnings when mounting with open={true} immediately.
  */
 const AgencyModal = ({
 	setAgencyModal,
@@ -37,6 +39,7 @@ const AgencyModal = ({
 }) => {
 	const [deleteModal, setDeleteModal] = useState(false)
 	const [selectedUserToDelete, setSelectedUserToDelete] = useState('')
+	const dialogOpen = useDelayedDialogOpen()
 
 	const handleClose = () => setAgencyModal(false)
 
@@ -57,7 +60,7 @@ const AgencyModal = ({
 	return (
 		<>
 			<Dialog data-component="AgencyModal"
-				open
+				open={dialogOpen}
 				handler={handleClose}
 				size="xl"
 				className="agency-modal rounded-md"

--- a/components/modals/admin/AgencyModal.jsx
+++ b/components/modals/admin/AgencyModal.jsx
@@ -128,9 +128,7 @@ const AgencyModal = ({
 									autoComplete="nope"
 								/>
 								{errors.email ? (
-									<p className="error">
-										Email should be at least 15 characters long
-									</p>
+									<p className="error">Enter a valid email address</p>
 								) : null}
 								<Button
 									onClick={handleAddAgencyUsers}

--- a/components/modals/admin/EditUserModal.jsx
+++ b/components/modals/admin/EditUserModal.jsx
@@ -604,6 +604,44 @@ const EditUserModal = ({
 			.replace(/_/g, ' ')
 			.replace(/^./, (match) => match.toUpperCase())
 
+	/**
+	 * Shared labeled switch row (contact, banned, other booleans).
+	 *
+	 * @param {{ checked: boolean, onChange: (e: Event) => void, label: string, disabled?: boolean, color?: string }} props
+	 */
+	const renderSwitchRow = ({
+		checked,
+		onChange,
+		label,
+		disabled = false,
+		color = 'blue',
+	}) => (
+		<div
+			className={`${style.modal_form_switch} ${disabled ? 'opacity-60' : ''}`}>
+			<Switch
+				checked={checked}
+				onChange={onChange}
+				disabled={disabled}
+				color={color}
+			/>
+			<Typography variant="small" className="mb-0">
+				{label}
+			</Typography>
+		</div>
+	)
+
+	const renderBannedSwitch = () =>
+		renderSwitchRow({
+			checked: banned,
+			onChange: (e) => {
+				const next = e.target.checked
+				setBanned(next)
+				handleBannedLocal(next)
+			},
+			label: banned ? 'Banned' : 'Not banned',
+			color: 'red',
+		})
+
 	const renderAdditionalField = (fieldKey, fieldValue) => {
 		const fieldConfig = mobileUserFieldTypes?.[fieldKey]
 		const fieldType = fieldConfig?.type || typeof fieldValue
@@ -626,17 +664,14 @@ const EditUserModal = ({
 							{formatFieldLabel(fieldKey)}
 						</Typography>
 					)}
-					<div className={`${style.modal_form_switch} ${disabled ? 'opacity-60' : ''}`}>
-						<Switch
-							checked={Boolean(fieldValue)}
-							onChange={(e) => commitMobileFieldChange(fieldKey, e.target.checked)}
-							disabled={disabled}
-							color="blue"
-						/>
-						<Typography variant="small" className="mb-0">
-							{statusLabel}
-						</Typography>
-					</div>
+					{renderSwitchRow({
+						checked: Boolean(fieldValue),
+						onChange: (e) =>
+							commitMobileFieldChange(fieldKey, e.target.checked),
+						label: statusLabel,
+						disabled,
+						color: 'blue',
+					})}
 				</div>
 			)
 		}
@@ -1000,22 +1035,7 @@ const EditUserModal = ({
 													)}
 												</div>
 											)}
-											<div key="banned">
-												<div className={style.modal_form_switch}>
-													<Switch
-														checked={banned}
-														onChange={(e) => {
-															const next = e.target.checked
-															setBanned(next)
-															handleBannedLocal(next)
-														}}
-														color="red"
-													/>
-													<Typography variant="small" className="mb-0">
-														{banned ? 'Banned' : 'Not banned'}
-													</Typography>
-												</div>
-											</div>
+											<div key="banned">{renderBannedSwitch()}</div>
 											{joiningDateEntry && (
 												<div key="joiningDate">
 													{renderAdditionalField(
@@ -1079,22 +1099,7 @@ const EditUserModal = ({
 						{/* Banned + Role when there are no mobileUserDetails */}
 						{Object.keys(mobileUserDetails || {}).length === 0 && (
 							<>
-								<div>
-									<div className={style.modal_form_switch}>
-										<Switch
-											checked={banned}
-											onChange={(e) => {
-												const next = e.target.checked
-												setBanned(next)
-												handleBannedLocal(next)
-											}}
-											color="red"
-										/>
-										<Typography variant="small" className="mb-0">
-											{banned ? 'Banned' : 'Not banned'}
-										</Typography>
-									</div>
-								</div>
+								<div>{renderBannedSwitch()}</div>
 								{customClaims.admin && (
 									<div>
 										<Typography

--- a/components/modals/admin/EditUserModal.jsx
+++ b/components/modals/admin/EditUserModal.jsx
@@ -590,11 +590,21 @@ const EditUserModal = ({
 		const disabled = !isAdmin
 
 		if (fieldType === 'boolean') {
+			const isContact = fieldKey === 'contact'
+			const statusLabel = isContact
+				? Boolean(fieldValue)
+					? 'Contact'
+					: 'No Contact'
+				: Boolean(fieldValue)
+					? 'Enabled'
+					: 'Disabled'
 			return (
 				<div>
-					<Typography variant="small" className="font-semibold mb-2">
-						{formatFieldLabel(fieldKey)}
-					</Typography>
+					{!isContact && (
+						<Typography variant="small" className="font-semibold mb-2">
+							{formatFieldLabel(fieldKey)}
+						</Typography>
+					)}
 					<div className={`${style.modal_form_switch} ${disabled ? 'opacity-60' : ''}`}>
 						<Switch
 							checked={Boolean(fieldValue)}
@@ -603,7 +613,7 @@ const EditUserModal = ({
 							color="blue"
 						/>
 						<Typography variant="small" className="mb-0">
-							{Boolean(fieldValue) ? 'Enabled' : 'Disabled'}
+							{statusLabel}
 						</Typography>
 					</div>
 				</div>
@@ -781,7 +791,16 @@ const EditUserModal = ({
 				<Typography variant="h3" color="blue" className="mt-0 mb-0">
 					User Info
 				</Typography>
-				<ModalCloseButton onClick={attemptCloseModal} />
+				<div className="flex items-center gap-3">
+					{unsavedWarning && (
+						<Typography
+							variant="small"
+							className="mb-0 font-bold text-red-600">
+							{unsavedWarning}
+						</Typography>
+					)}
+					<ModalCloseButton onClick={attemptCloseModal} />
+				</div>
 			</DialogHeader>
 			<DialogBody className="overflow-y-auto max-h-[calc(100dvh-8rem)]">
 				<form onSubmit={(e) => { onFormSubmit(e); setHasUnsavedChanges(false); setUnsavedWarning('') }}>
@@ -905,13 +924,48 @@ const EditUserModal = ({
 									className="md:col-span-2 mt-4 mb-0">
 									Additional details
 								</Typography>
-								{Object.entries(mobileUserDetails)
-									.filter(([k]) => k !== 'city' && k !== 'state')
-									.map(([fieldKey, fieldValue]) => (
-										<div key={fieldKey} className="md:col-span-2">
-											{renderAdditionalField(fieldKey, fieldValue)}
-										</div>
-									))}
+								{(() => {
+									const detailEntries = Object.entries(
+										mobileUserDetails,
+									).filter(
+										([k]) => k !== 'city' && k !== 'state',
+									)
+									const halfWidthKeys = ['contact', 'joiningDate']
+									const halfWidthEntries = halfWidthKeys
+										.map((key) =>
+											detailEntries.find(([k]) => k === key),
+										)
+										.filter(Boolean)
+									const fullWidthEntries = detailEntries.filter(
+										([k]) => !halfWidthKeys.includes(k),
+									)
+									return (
+										<>
+											{halfWidthEntries.map(
+												([fieldKey, fieldValue]) => (
+													<div key={fieldKey}>
+														{renderAdditionalField(
+															fieldKey,
+															fieldValue,
+														)}
+													</div>
+												),
+											)}
+											{fullWidthEntries.map(
+												([fieldKey, fieldValue]) => (
+													<div
+														key={fieldKey}
+														className="md:col-span-2">
+														{renderAdditionalField(
+															fieldKey,
+															fieldValue,
+														)}
+													</div>
+												),
+											)}
+										</>
+									)
+								})()}
 								{!isAdmin && (
 									<Typography variant="small" className="md:col-span-2 text-slate-600 mb-0">
 										Only admins can edit these values.
@@ -920,63 +974,64 @@ const EditUserModal = ({
 							</Fragment>
 						)}
 
-						<div className={style.modal_form_switch}>
-							<Typography variant="small" className="font-semibold mb-0 mr-2">
-								Banned
-							</Typography>
-							<Switch
-								checked={banned}
-								onChange={(e) => {
-									const next = e.target.checked
-									setBanned(next)
-									handleBannedLocal(next)
-								}}
-								color="red"
-							/>
-							<Typography variant="small" className="mb-0">
-								{banned ? 'Banned' : 'Not banned'}
-							</Typography>
+						<div>
+							<div className={style.modal_form_switch}>
+								<Switch
+									checked={banned}
+									onChange={(e) => {
+										const next = e.target.checked
+										setBanned(next)
+										handleBannedLocal(next)
+									}}
+									color="red"
+								/>
+								<Typography variant="small" className="mb-0">
+									{banned ? 'Banned' : 'Not banned'}
+								</Typography>
+							</div>
 						</div>
 
 						{customClaims.admin && (
 							<>
-								<Typography variant="h5" color="blue" className="md:col-span-2 mt-2 mb-0">
-									Permissions
-								</Typography>
-								<div className={`${style.modal_form_radio_container} md:col-span-2`}>
-									<label htmlFor='admin'>
-										<input
-											type='radio'
-											value='Admin'
-											id='admin'
-											checked={userRole === "Admin"}
-											onChange={() => handleRoleLocal("Admin")}
-											className={style.modal_form_radio}
-										/>
-										Admin
-									</label>
-									<label htmlFor='agency'>
-										<input
-											type='radio'
-											value='Agency'
-											id='agency'
-											checked={userRole === "Agency"}
-											onChange={() => handleRoleLocal("Agency")}
-											className={style.modal_form_radio}
-										/>
-										Agency
-									</label>
-									<label htmlFor='user'>
-										<input
-											type='radio'
-											value='User'
-											id='user'
-											checked={userRole === "User"}
-											onChange={() => handleRoleLocal("User")}
-											className={style.modal_form_radio}
-										/>
-										User
-									</label>
+								<div>
+									<Typography variant="small" className="font-semibold mb-2">
+										Role
+									</Typography>
+									<div className={style.modal_form_radio_container}>
+										<label htmlFor='admin'>
+											<input
+												type='radio'
+												value='Admin'
+												id='admin'
+												checked={userRole === "Admin"}
+												onChange={() => handleRoleLocal("Admin")}
+												className={style.modal_form_radio}
+											/>
+											Admin
+										</label>
+										<label htmlFor='agency'>
+											<input
+												type='radio'
+												value='Agency'
+												id='agency'
+												checked={userRole === "Agency"}
+												onChange={() => handleRoleLocal("Agency")}
+												className={style.modal_form_radio}
+											/>
+											Agency
+										</label>
+										<label htmlFor='user'>
+											<input
+												type='radio'
+												value='User'
+												id='user'
+												checked={userRole === "User"}
+												onChange={() => handleRoleLocal("User")}
+												className={style.modal_form_radio}
+											/>
+											User
+										</label>
+									</div>
 								</div>
 								{userRole === "Agency" && (
 									<div className="md:col-span-2">
@@ -1001,23 +1056,29 @@ const EditUserModal = ({
 								)}
 							</>
 						)}
-						{unsavedWarning && (
-							<Typography variant="small" className="md:col-span-2 text-red-600 text-center mb-0">
-								{unsavedWarning}
-							</Typography>
-						)}
 						{mobileFieldFormError && (
 							<Typography variant="small" className="md:col-span-2 text-red-600 text-center mb-0">
 								{mobileFieldFormError}
 							</Typography>
 						)}
-						<div className='md:col-span-2 flex flex-col items-center gap-2 pt-2'>
+						<div className="md:col-span-2 flex flex-col items-center gap-2 pt-2">
 							<Typography variant="small" className="mb-0">
 								Current Role: {userRole}
 							</Typography>
-							<Button type='submit'>
-								Update User
-							</Button>
+							<div className="flex items-center gap-3">
+								<Button
+									type="button"
+									variant="outlined"
+									color="blue-gray"
+									onClick={() => {
+										setUnsavedWarning('')
+										setHasUnsavedChanges(false)
+										setUserEditModal(false)
+									}}>
+									Cancel
+								</Button>
+								<Button type="submit">Update User</Button>
+							</div>
 						</div>
 					</div>
 				</form>

--- a/components/modals/admin/EditUserModal.jsx
+++ b/components/modals/admin/EditUserModal.jsx
@@ -65,6 +65,14 @@ const EditUserModal = ({
 	const [locationError, setLocationError] = useState('')
 	const [selectedStateOption, setSelectedStateOption] = useState(null)
 	const [selectedCityOption, setSelectedCityOption] = useState(null)
+	// Delay Dialog open one tick: MT Dialog + Floating UI 0.19 logs aria-hidden
+	// "not contained inside body" when mounting with open={true} immediately.
+	const [dialogOpen, setDialogOpen] = useState(false)
+
+	useEffect(() => {
+		const id = window.setTimeout(() => setDialogOpen(true), 0)
+		return () => window.clearTimeout(id)
+	}, [])
 
 	const stateOptions = useMemo(() => State.getStatesOfCountry('US'), [])
 	const cityOptions = useMemo(() => {
@@ -751,7 +759,7 @@ const EditUserModal = ({
 
 	return (
 		<Dialog data-component="EditUserModal"
-			open
+			open={dialogOpen}
 			handler={attemptCloseModal}
 			size="xl"
 			className="edit-user-modal rounded-md"
@@ -775,7 +783,7 @@ const EditUserModal = ({
 				</Typography>
 				<ModalCloseButton onClick={attemptCloseModal} />
 			</DialogHeader>
-			<DialogBody className="overflow-y-auto max-h-[calc(100dvh-8rem)] pt-0">
+			<DialogBody className="overflow-y-auto max-h-[calc(100dvh-8rem)]">
 				<form onSubmit={(e) => { onFormSubmit(e); setHasUnsavedChanges(false); setUnsavedWarning('') }}>
 					<div className={style.modal_form_container}>
 						<div className="md:col-span-2">

--- a/components/modals/admin/EditUserModal.jsx
+++ b/components/modals/admin/EditUserModal.jsx
@@ -808,7 +808,7 @@ const EditUserModal = ({
 					return true
 				},
 			}}>
-			<DialogHeader className="justify-between gap-4">
+			<DialogHeader className="justify-between gap-4 text-base font-normal">
 				<Typography variant="h3" color="blue" className="mt-0 mb-0">
 					User Info
 				</Typography>
@@ -823,7 +823,7 @@ const EditUserModal = ({
 					<ModalCloseButton onClick={attemptCloseModal} />
 				</div>
 			</DialogHeader>
-			<DialogBody className="overflow-y-auto max-h-[calc(100dvh-8rem)]">
+			<DialogBody className="overflow-y-auto max-h-[calc(100dvh-8rem)] text-base">
 				<form
 					onSubmit={(e) => {
 						if (isEditingLocation && !handleLocationSave()) {
@@ -1040,6 +1040,7 @@ const EditUserModal = ({
 																	<Tab
 																		key={value}
 																		value={value}
+																		className="text-sm"
 																		onClick={() =>
 																			handleRoleLocal(value)
 																		}>
@@ -1107,6 +1108,7 @@ const EditUserModal = ({
 													<Tab
 														key={value}
 														value={value}
+														className="text-sm"
 														onClick={() => handleRoleLocal(value)}>
 														&nbsp;&nbsp;{label}&nbsp;&nbsp;
 													</Tab>

--- a/components/modals/admin/EditUserModal.jsx
+++ b/components/modals/admin/EditUserModal.jsx
@@ -1,4 +1,5 @@
 import React, { Fragment, useEffect, useMemo, useState } from "react"
+import { flushSync } from 'react-dom'
 import FormInput from '../../ui/FormInput'
 import FormTextarea from '../../ui/FormTextarea'
 import FormSelect from '../../ui/FormSelect'
@@ -10,8 +11,18 @@ import {
 	DialogBody,
 	DialogHeader,
 	Switch,
+	Tabs,
+	TabsHeader,
+	Tab,
 	Typography,
 } from '@material-tailwind/react'
+
+/** Role picker tabs — values match Firestore `userRole` / Users ROLE_TABS. */
+const ROLE_TABS = [
+	{ label: 'Admin', value: 'Admin' },
+	{ label: 'Agency', value: 'Agency' },
+	{ label: 'User', value: 'User' },
+]
 
 const EditUserModal = ({
 	userEditingUID,
@@ -46,8 +57,6 @@ const EditUserModal = ({
 		modal_form_container:
 			"grid justify-center md:gap-5 lg:gap-5 grid-cols-1 md:grid-cols-2 auto-cols-auto",
 		modal_form_switch: "flex mb-4 items-center gap-2",
-		modal_form_radio_container: "flex gap-4 flex-wrap mb-4",
-		modal_form_radio: "mr-1",
 	}
 
 	const isAdmin = Boolean(customClaims?.admin)
@@ -205,7 +214,6 @@ const EditUserModal = ({
 		onMobileFieldChange && onMobileFieldChange(key, value)
 	}
 	const handleNameLocal = (e) => { setHasUnsavedChanges(true); onNameChange && onNameChange(e) }
-	const handleEmailLocal = (e) => { setHasUnsavedChanges(true); onEmailChange && onEmailChange(e) }
 	const handleRoleLocal = (role) => { setHasUnsavedChanges(true); onRoleChange && onRoleChange(role) }
 	const handleAgencyLocal = (e) => { setHasUnsavedChanges(true); onAgencyChange && onAgencyChange(e) }
 	const handleBannedLocal = (checked) => { setHasUnsavedChanges(true); onBannedChange && onBannedChange(checked) }
@@ -326,70 +334,83 @@ const EditUserModal = ({
 		setLocationError('')
 	}, [mobileUserDetails, userEditing, stateOptions])
 
-	const handleLocationSave = () => {
-		if (!isAdmin) return
+	/**
+	 * Commit State/City drafts into parent `mobileUserDetails`.
+	 * Used when both dropdowns are set (on city pick) and again on Update User if still editing.
+	 *
+	 * @param {object} [stateOption]
+	 * @param {object} [cityOption]
+	 * @returns {boolean} false when validation fails
+	 */
+	const handleLocationSave = (
+		stateOption = selectedStateOption,
+		cityOption = selectedCityOption,
+	) => {
+		if (!isAdmin) return true
 
-		if (!selectedStateOption || !selectedCityOption) {
+		if (!stateOption || !cityOption) {
 			setLocationError('Select both a state and a city.')
-			return
+			return false
 		}
 
-		const cityText = selectedCityOption.name?.trim?.() || ''
-		const stateText = selectedStateOption.name?.trim?.() || ''
+		const cityText = cityOption.name?.trim?.() || ''
+		const stateText = stateOption.name?.trim?.() || ''
 
 		const cityType = mobileUserFieldTypes?.city?.type
 		const stateType = mobileUserFieldTypes?.state?.type
 
-		// Start from the actual current city map only (avoid falling back to any generic originalValue)
 		const prevCity = mobileUserDetails?.city
-
 		let nextCityValue = null
 
 		if (cityType === 'object' || typeof prevCity === 'object') {
-			// Preferred schema: everything lives under the city map
 			nextCityValue = mergeCityMap(prevCity, {
 				name: cityText,
-				stateCode: selectedCityOption.stateCode || selectedStateOption.isoCode,
-				countryCode: selectedCityOption.countryCode || selectedStateOption.countryCode,
+				stateCode: cityOption.stateCode || stateOption.isoCode,
+				countryCode: cityOption.countryCode || stateOption.countryCode,
 				latitude:
-					selectedCityOption.latitude != null
-						? Number(selectedCityOption.latitude)
+					cityOption.latitude != null
+						? Number(cityOption.latitude)
 						: undefined,
 				longitude:
-					selectedCityOption.longitude != null
-						? Number(selectedCityOption.longitude)
+					cityOption.longitude != null
+						? Number(cityOption.longitude)
 						: undefined,
 			})
-			commitMobileFieldChange('city', nextCityValue)
 		} else if (cityType === 'array') {
 			nextCityValue = cityText ? [cityText] : null
-			commitMobileFieldChange('city', nextCityValue)
 		} else {
-			// city is a plain string/number field
-			commitMobileFieldChange('city', cityText || null)
+			nextCityValue = cityText || null
 		}
 
-		// Only write a separate top-level `state` field if the schema explicitly defines it
+		let nextStateValue = null
+		let shouldWriteState = false
 		if (stateType) {
-			let nextStateValue = stateText || null
+			shouldWriteState = true
+			nextStateValue = stateText || null
 			if (stateType === 'object') {
 				const prevState = mobileUserDetails?.state
-				const statePayload = {
+				nextStateValue = {
 					...(prevState && typeof prevState === 'object' && !Array.isArray(prevState)
 						? prevState
 						: {}),
-					name: selectedStateOption.name,
-					countryCode: selectedStateOption.countryCode,
-					isoCode: selectedStateOption.isoCode,
+					name: stateOption.name,
+					countryCode: stateOption.countryCode,
+					isoCode: stateOption.isoCode,
 				}
-				nextStateValue = statePayload
 			}
 			if (stateType === 'array' && stateText) nextStateValue = [stateText]
-			commitMobileFieldChange('state', nextStateValue)
 		}
+
+		flushSync(() => {
+			commitMobileFieldChange('city', nextCityValue)
+			if (shouldWriteState) {
+				commitMobileFieldChange('state', nextStateValue)
+			}
+		})
 
 		setLocationError('')
 		setIsEditingLocation(false)
+		return true
 	}
 
 	const clearStructuredFieldError = (fieldKey) => {
@@ -803,9 +824,23 @@ const EditUserModal = ({
 				</div>
 			</DialogHeader>
 			<DialogBody className="overflow-y-auto max-h-[calc(100dvh-8rem)]">
-				<form onSubmit={(e) => { onFormSubmit(e); setHasUnsavedChanges(false); setUnsavedWarning('') }}>
+				<form
+					onSubmit={(e) => {
+						if (isEditingLocation && !handleLocationSave()) {
+							e.preventDefault()
+							return
+						}
+						onFormSubmit(e)
+						setHasUnsavedChanges(false)
+						setUnsavedWarning('')
+					}}>
 					<div className={style.modal_form_container}>
-						<div className="md:col-span-2">
+						<div
+							className={
+								customClaims.admin && userRole === 'Agency'
+									? undefined
+									: 'md:col-span-2'
+							}>
 							<FormInput
 								id="name"
 								type="text"
@@ -814,7 +849,29 @@ const EditUserModal = ({
 								defaultValue={userEditing.name || 'Name not set'}
 							/>
 						</div>
-						<div className="md:col-span-2">
+						{customClaims.admin && userRole === 'Agency' && (
+							<div>
+								<FormSelect
+									id="agency"
+									label="Agency"
+									value={
+										agenciesArray.find((a) => a.id === selectedAgency) ||
+										null
+									}
+									options={agenciesArray}
+									getOptionLabel={(option) => option.name}
+									getOptionValue={(option) => option.id}
+									onChange={(option) => {
+										handleAgencyLocal({
+											preventDefault: () => {},
+											target: { value: option?.id || '' },
+										})
+									}}
+									isClearable
+								/>
+							</div>
+						)}
+						<div>
 							<FormInput
 								id="userId"
 								label="User ID"
@@ -822,85 +879,92 @@ const EditUserModal = ({
 								disabled
 							/>
 						</div>
-						<div className="md:col-span-2">
+						<div>
 							<FormInput
 								id="email"
 								type="email"
 								label="Email"
-								onChange={handleEmailLocal}
-								defaultValue={userEditing.email}
+								value={email ?? ''}
+								disabled
 							/>
 						</div>
 
 						{/* Location (City & State) */}
-						<div className='md:col-span-2 flex items-center justify-between pt-2'>
-							<Typography variant="h5" color="blue" className="mt-0 mb-0">
+						<div className="md:col-span-2 pt-2">
+							<Typography variant="small" className="font-semibold mb-2">
 								Location
 							</Typography>
-							{isAdmin && (
-								<Button
-									type="button"
-									variant="text"
-									size="sm"
-									className="normal-case"
-									onClick={() => {
-										setIsEditingLocation((s) => !s)
-										setLocationError('')
-									}}>
-									{isEditingLocation ? 'Cancel' : 'Change Location'}
-								</Button>
-							)}
+							<div className="flex items-center gap-2">
+								{!isEditingLocation && (
+									<Typography variant="small" className="text-slate-700 mb-0">
+										{cityDraft || '—'}, {stateDraft || '—'}
+									</Typography>
+								)}
+								{isAdmin && (
+									<button
+										type="button"
+										className="shrink-0 text-xs font-medium text-brand underline underline-offset-2 hover:opacity-75"
+										onClick={() => {
+											setIsEditingLocation((s) => !s)
+											setLocationError('')
+										}}>
+										{isEditingLocation ? 'Cancel' : 'Change'}
+									</button>
+								)}
+							</div>
 						</div>
 
-						{!isEditingLocation && (
-							<Typography variant="small" className="md:col-span-2 text-slate-700 mb-0">
-								Current: {cityDraft || '—'}, {stateDraft || '—'}
-							</Typography>
+						{isEditingLocation && (
+							<>
+								<div>
+									<FormSelect
+										id='state'
+										label='State'
+										isDisabled={!isAdmin}
+										value={selectedStateOption}
+										onChange={(option) => {
+											setSelectedStateOption(option || null)
+											setSelectedCityOption(null)
+											setStateDraft(option?.name || '')
+											setCityDraft('')
+											setHasUnsavedChanges(true)
+											setLocationError('')
+										}}
+										options={stateOptions}
+										getOptionLabel={(option) => option.name}
+										getOptionValue={(option) => option.isoCode}
+									/>
+								</div>
+
+								<div>
+									<FormSelect
+										id='city'
+										label={
+											selectedStateOption ? 'City' : 'Select a state first'
+										}
+										isDisabled={!isAdmin || !selectedStateOption}
+										value={selectedCityOption}
+										onChange={(option) => {
+											setSelectedCityOption(option || null)
+											setCityDraft(option?.name || '')
+											setHasUnsavedChanges(true)
+											setLocationError('')
+											if (option && selectedStateOption) {
+												handleLocationSave(
+													selectedStateOption,
+													option,
+												)
+											}
+										}}
+										options={cityOptions}
+										getOptionLabel={(option) => option.name}
+										getOptionValue={(option) =>
+											`${option.name}-${option.stateCode}-${option.latitude}-${option.longitude}`
+										}
+									/>
+								</div>
+							</>
 						)}
-
-						<div>
-							<FormSelect
-								id='state'
-								label='State'
-								isDisabled={!isAdmin || !isEditingLocation}
-								value={selectedStateOption}
-								onChange={(option) => {
-									setSelectedStateOption(option || null)
-									setSelectedCityOption(null)
-									setStateDraft(option?.name || '')
-									setCityDraft('')
-									setHasUnsavedChanges(true)
-									setLocationError('')
-								}}
-								options={stateOptions}
-								getOptionLabel={(option) => option.name}
-								getOptionValue={(option) => option.isoCode}
-							/>
-						</div>
-
-						<div>
-							<FormSelect
-								id='city'
-								label={
-									selectedStateOption ? 'City' : 'Select a state first'
-								}
-								isDisabled={
-									!isAdmin || !isEditingLocation || !selectedStateOption
-								}
-								value={selectedCityOption}
-								onChange={(option) => {
-									setSelectedCityOption(option || null)
-									setCityDraft(option?.name || '')
-									setHasUnsavedChanges(true)
-									setLocationError('')
-								}}
-								options={cityOptions}
-								getOptionLabel={(option) => option.name}
-								getOptionValue={(option) =>
-									`${option.name}-${option.stateCode}-${option.latitude}-${option.longitude}`
-								}
-							/>
-						</div>
 
 						{locationError && (
 							<Typography variant="small" className="md:col-span-2 text-red-600 mb-0">
@@ -908,50 +972,87 @@ const EditUserModal = ({
 							</Typography>
 						)}
 
-						{isAdmin && isEditingLocation && (
-							<div className='md:col-span-2 flex justify-end'>
-								<Button type="button" onClick={handleLocationSave}>
-									Save Location
-								</Button>
-							</div>
-						)}
-
 						{Object.keys(mobileUserDetails || {}).length > 0 && (
 							<Fragment>
-								<Typography
-									variant="h5"
-									color="blue"
-									className="md:col-span-2 mt-4 mb-0">
-									Additional details
-								</Typography>
 								{(() => {
 									const detailEntries = Object.entries(
 										mobileUserDetails,
 									).filter(
 										([k]) => k !== 'city' && k !== 'state',
 									)
-									const halfWidthKeys = ['contact', 'joiningDate']
-									const halfWidthEntries = halfWidthKeys
-										.map((key) =>
-											detailEntries.find(([k]) => k === key),
-										)
-										.filter(Boolean)
-									const fullWidthEntries = detailEntries.filter(
-										([k]) => !halfWidthKeys.includes(k),
+									const contactEntry = detailEntries.find(
+										([k]) => k === 'contact',
+									)
+									const joiningDateEntry = detailEntries.find(
+										([k]) => k === 'joiningDate',
+									)
+									const otherEntries = detailEntries.filter(
+										([k]) =>
+											k !== 'contact' && k !== 'joiningDate',
 									)
 									return (
 										<>
-											{halfWidthEntries.map(
-												([fieldKey, fieldValue]) => (
-													<div key={fieldKey}>
-														{renderAdditionalField(
-															fieldKey,
-															fieldValue,
-														)}
-													</div>
-												),
+											{contactEntry && (
+												<div key="contact">
+													{renderAdditionalField(
+														contactEntry[0],
+														contactEntry[1],
+													)}
+												</div>
 											)}
-											{fullWidthEntries.map(
+											<div key="banned">
+												<div className={style.modal_form_switch}>
+													<Switch
+														checked={banned}
+														onChange={(e) => {
+															const next = e.target.checked
+															setBanned(next)
+															handleBannedLocal(next)
+														}}
+														color="red"
+													/>
+													<Typography variant="small" className="mb-0">
+														{banned ? 'Banned' : 'Not banned'}
+													</Typography>
+												</div>
+											</div>
+											{joiningDateEntry && (
+												<div key="joiningDate">
+													{renderAdditionalField(
+														joiningDateEntry[0],
+														joiningDateEntry[1],
+													)}
+												</div>
+											)}
+											{customClaims.admin && (
+												<div key="role">
+													<Typography
+														variant="small"
+														className="font-semibold mb-2">
+														Role
+													</Typography>
+													<Tabs
+														value={userRole || 'User'}
+														className="w-max">
+														<TabsHeader>
+															{ROLE_TABS.map(
+																({ label, value }) => (
+																	<Tab
+																		key={value}
+																		value={value}
+																		onClick={() =>
+																			handleRoleLocal(value)
+																		}>
+																		&nbsp;&nbsp;{label}
+																		&nbsp;&nbsp;
+																	</Tab>
+																),
+															)}
+														</TabsHeader>
+													</Tabs>
+												</div>
+											)}
+											{otherEntries.map(
 												([fieldKey, fieldValue]) => (
 													<div
 														key={fieldKey}
@@ -974,84 +1075,44 @@ const EditUserModal = ({
 							</Fragment>
 						)}
 
-						<div>
-							<div className={style.modal_form_switch}>
-								<Switch
-									checked={banned}
-									onChange={(e) => {
-										const next = e.target.checked
-										setBanned(next)
-										handleBannedLocal(next)
-									}}
-									color="red"
-								/>
-								<Typography variant="small" className="mb-0">
-									{banned ? 'Banned' : 'Not banned'}
-								</Typography>
-							</div>
-						</div>
-
-						{customClaims.admin && (
+						{/* Banned + Role when there are no mobileUserDetails */}
+						{Object.keys(mobileUserDetails || {}).length === 0 && (
 							<>
 								<div>
-									<Typography variant="small" className="font-semibold mb-2">
-										Role
-									</Typography>
-									<div className={style.modal_form_radio_container}>
-										<label htmlFor='admin'>
-											<input
-												type='radio'
-												value='Admin'
-												id='admin'
-												checked={userRole === "Admin"}
-												onChange={() => handleRoleLocal("Admin")}
-												className={style.modal_form_radio}
-											/>
-											Admin
-										</label>
-										<label htmlFor='agency'>
-											<input
-												type='radio'
-												value='Agency'
-												id='agency'
-												checked={userRole === "Agency"}
-												onChange={() => handleRoleLocal("Agency")}
-												className={style.modal_form_radio}
-											/>
-											Agency
-										</label>
-										<label htmlFor='user'>
-											<input
-												type='radio'
-												value='User'
-												id='user'
-												checked={userRole === "User"}
-												onChange={() => handleRoleLocal("User")}
-												className={style.modal_form_radio}
-											/>
-											User
-										</label>
+									<div className={style.modal_form_switch}>
+										<Switch
+											checked={banned}
+											onChange={(e) => {
+												const next = e.target.checked
+												setBanned(next)
+												handleBannedLocal(next)
+											}}
+											color="red"
+										/>
+										<Typography variant="small" className="mb-0">
+											{banned ? 'Banned' : 'Not banned'}
+										</Typography>
 									</div>
 								</div>
-								{userRole === "Agency" && (
-									<div className="md:col-span-2">
-										<FormSelect
-											id="agency"
-											label="Agency"
-											value={
-												agenciesArray.find((a) => a.id === selectedAgency) || null
-											}
-											options={agenciesArray}
-											getOptionLabel={(option) => option.name}
-											getOptionValue={(option) => option.id}
-											onChange={(option) => {
-												handleAgencyLocal({
-													preventDefault: () => {},
-													target: { value: option?.id || '' },
-												})
-											}}
-											isClearable
-										/>
+								{customClaims.admin && (
+									<div>
+										<Typography
+											variant="small"
+											className="font-semibold mb-2">
+											Role
+										</Typography>
+										<Tabs value={userRole || 'User'} className="w-max">
+											<TabsHeader>
+												{ROLE_TABS.map(({ label, value }) => (
+													<Tab
+														key={value}
+														value={value}
+														onClick={() => handleRoleLocal(value)}>
+														&nbsp;&nbsp;{label}&nbsp;&nbsp;
+													</Tab>
+												))}
+											</TabsHeader>
+										</Tabs>
 									</div>
 								)}
 							</>
@@ -1061,24 +1122,19 @@ const EditUserModal = ({
 								{mobileFieldFormError}
 							</Typography>
 						)}
-						<div className="md:col-span-2 flex flex-col items-center gap-2 pt-2">
-							<Typography variant="small" className="mb-0">
-								Current Role: {userRole}
-							</Typography>
-							<div className="flex items-center gap-3">
-								<Button
-									type="button"
-									variant="outlined"
-									color="blue-gray"
-									onClick={() => {
-										setUnsavedWarning('')
-										setHasUnsavedChanges(false)
-										setUserEditModal(false)
-									}}>
-									Cancel
-								</Button>
-								<Button type="submit">Update User</Button>
-							</div>
+						<div className="md:col-span-2 flex justify-end gap-3 pt-2">
+							<Button
+								type="button"
+								variant="outlined"
+								color="blue-gray"
+								onClick={() => {
+									setUnsavedWarning('')
+									setHasUnsavedChanges(false)
+									setUserEditModal(false)
+								}}>
+								Cancel
+							</Button>
+							<Button type="submit">Update User</Button>
 						</div>
 					</div>
 				</form>

--- a/components/modals/admin/EditUserModal.jsx
+++ b/components/modals/admin/EditUserModal.jsx
@@ -5,6 +5,7 @@ import FormTextarea from '../../ui/FormTextarea'
 import FormSelect from '../../ui/FormSelect'
 import ModalCloseButton from '../../ui/ModalCloseButton'
 import { State, City } from "country-state-city"
+import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
 import {
 	Button,
 	Dialog,
@@ -74,14 +75,7 @@ const EditUserModal = ({
 	const [locationError, setLocationError] = useState('')
 	const [selectedStateOption, setSelectedStateOption] = useState(null)
 	const [selectedCityOption, setSelectedCityOption] = useState(null)
-	// Delay Dialog open one tick: MT Dialog + Floating UI 0.19 logs aria-hidden
-	// "not contained inside body" when mounting with open={true} immediately.
-	const [dialogOpen, setDialogOpen] = useState(false)
-
-	useEffect(() => {
-		const id = window.setTimeout(() => setDialogOpen(true), 0)
-		return () => window.clearTimeout(id)
-	}, [])
+	const dialogOpen = useDelayedDialogOpen()
 
 	const stateOptions = useMemo(() => State.getStatesOfCountry('US'), [])
 	const cityOptions = useMemo(() => {

--- a/components/modals/admin/NewAgencyModal.jsx
+++ b/components/modals/admin/NewAgencyModal.jsx
@@ -1,8 +1,8 @@
-import React from 'react'
 import FormInput from '../../ui/FormInput'
 import FormSelect from '../../ui/FormSelect'
 import ModalCloseButton from '../../ui/ModalCloseButton'
 import { State, City } from 'country-state-city'
+import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
 import {
 	Button,
 	Dialog,
@@ -12,7 +12,8 @@ import {
 } from '@material-tailwind/react'
 
 /**
- * Mount when visible; Dialog is always open while mounted.
+ * Mount when visible; Dialog opens one tick later to avoid Floating UI
+ * aria-hidden warnings when mounting with open={true} immediately.
  */
 const NewAgencyModal = ({
 	setNewAgencyModal,
@@ -27,10 +28,11 @@ const NewAgencyModal = ({
 	errors,
 }) => {
 	const handleClose = () => setNewAgencyModal(false)
+	const dialogOpen = useDelayedDialogOpen()
 
 	return (
 		<Dialog data-component="NewAgencyModal"
-			open
+			open={dialogOpen}
 			handler={handleClose}
 			size="md"
 			className="new-agency-modal rounded-md"

--- a/components/modals/admin/NewUserModal.jsx
+++ b/components/modals/admin/NewUserModal.jsx
@@ -28,8 +28,8 @@ const NewUserModal = ({
 			size="md"
 			className="new-user-modal rounded-md">
 			<DialogHeader className="justify-between gap-4">
-				<Typography variant="h3" color="blue" className="mt-0 mb-0">
-					Add new agency user
+				<Typography variant="h2" color="blue" className="mt-0 mb-0">
+					Invite user
 				</Typography>
 				<ModalCloseButton onClick={handleClose} />
 			</DialogHeader>
@@ -38,7 +38,7 @@ const NewUserModal = ({
 					<FormInput
 						id="userEmail"
 						type="email"
-						label="Agency user email"
+						label="Email to invite"
 						value={newUserEmail}
 						onChange={onNewUserEmail}
 						autoComplete="email"
@@ -48,7 +48,7 @@ const NewUserModal = ({
 						<p className="error text-red-500 text-sm font-light">{errors.email}</p>
 					)}
 					<Button type="submit" id="userNew">
-						Add User
+						Send invite
 					</Button>
 				</form>
 			</DialogBody>

--- a/components/modals/admin/NewUserModal.jsx
+++ b/components/modals/admin/NewUserModal.jsx
@@ -1,6 +1,7 @@
 import FormInput from '../../ui/FormInput'
 import ModalCloseButton from '../../ui/ModalCloseButton'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
+import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
 import {
 	Button,
 	Dialog,
@@ -21,14 +22,7 @@ const NewUserModal = ({
 	errors,
 }) => {
 	const handleClose = () => setNewUserModal(false)
-	// Delay Dialog open one tick: MT Dialog + Floating UI 0.19 logs aria-hidden
-	// "not contained inside body" when mounting with open={true} immediately.
-	const [dialogOpen, setDialogOpen] = useState(false)
-
-	useEffect(() => {
-		const id = window.setTimeout(() => setDialogOpen(true), 0)
-		return () => window.clearTimeout(id)
-	}, [])
+	const dialogOpen = useDelayedDialogOpen()
 
 	return (
 		<Dialog data-component="NewUserModal"

--- a/components/modals/admin/NewUserModal.jsx
+++ b/components/modals/admin/NewUserModal.jsx
@@ -1,6 +1,6 @@
 import FormInput from '../../ui/FormInput'
 import ModalCloseButton from '../../ui/ModalCloseButton'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import {
 	Button,
 	Dialog,
@@ -10,7 +10,8 @@ import {
 } from '@material-tailwind/react'
 
 /**
- * Mount when visible; Dialog is always open while mounted.
+ * Mount when visible; Dialog opens one tick later to avoid Floating UI
+ * aria-hidden warnings when mounting with open={true} immediately.
  */
 const NewUserModal = ({
 	setNewUserModal,
@@ -20,10 +21,18 @@ const NewUserModal = ({
 	errors,
 }) => {
 	const handleClose = () => setNewUserModal(false)
+	// Delay Dialog open one tick: MT Dialog + Floating UI 0.19 logs aria-hidden
+	// "not contained inside body" when mounting with open={true} immediately.
+	const [dialogOpen, setDialogOpen] = useState(false)
+
+	useEffect(() => {
+		const id = window.setTimeout(() => setDialogOpen(true), 0)
+		return () => window.clearTimeout(id)
+	}, [])
 
 	return (
 		<Dialog data-component="NewUserModal"
-			open
+			open={dialogOpen}
 			handler={handleClose}
 			size="md"
 			className="new-user-modal rounded-md">

--- a/components/modals/common/ConfirmModal.jsx
+++ b/components/modals/common/ConfirmModal.jsx
@@ -19,6 +19,7 @@ import { RiDeleteBin2Fill } from 'react-icons/ri'
 import { BiLogOut } from 'react-icons/bi'
 import { IoMdRefresh } from 'react-icons/io'
 import { useTranslation } from 'next-i18next'
+import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
 import {
 	Button,
 	Dialog,
@@ -35,8 +36,8 @@ import {
  * Reset Report) with appropriate icons. The modal includes both confirm and
  * cancel buttons, with the confirm action being triggered on form submission.
  *
- * Mount when visible (`{show && <ConfirmModal ... />}`); Dialog is always open
- * while mounted, matching existing call sites.
+ * Mount when visible (`{show && <ConfirmModal ... />}`); Dialog opens one tick
+ * later to avoid Floating UI aria-hidden warnings.
  *
  * @param {Object} props - Component props
  * @param {Function} props.func - Function to execute when user confirms the action
@@ -56,6 +57,7 @@ import {
  */
 const ConfirmModal = ({ func, title, subtitle, CTA, closeModal }) => {
 	const { t } = useTranslation('Profile')
+	const dialogOpen = useDelayedDialogOpen()
 
 	/**
 	 * Handles form submission when user confirms the action.
@@ -94,7 +96,7 @@ const ConfirmModal = ({ func, title, subtitle, CTA, closeModal }) => {
 
 	return (
 		<Dialog data-component="ConfirmModal"
-			open
+			open={dialogOpen}
 			handler={handleCancel}
 			size="xs"
 			className="confirm-modal-root confirm-modal rounded-md">

--- a/components/modals/common/DeleteModal.jsx
+++ b/components/modals/common/DeleteModal.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { RiDeleteBin2Fill } from 'react-icons/ri'
 import { useTranslation } from 'next-i18next'
+import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
 import {
 	Button,
 	Dialog,
@@ -12,11 +13,12 @@ import {
 /**
  * Delete confirmation dialog (Material Tailwind Dialog).
  *
- * Mount when visible (`{show && <DeleteModal ... />}`); Dialog is always open
- * while mounted, matching existing call sites.
+ * Mount when visible (`{show && <DeleteModal ... />}`); Dialog opens one tick
+ * later to avoid Floating UI aria-hidden warnings.
  */
 const DeleteModal = ({ func, title, subtitle, CTA, closeModal }) => {
 	const { t } = useTranslation('Profile')
+	const dialogOpen = useDelayedDialogOpen()
 
 	const handleSubmit = (e) => {
 		e.preventDefault()
@@ -29,7 +31,7 @@ const DeleteModal = ({ func, title, subtitle, CTA, closeModal }) => {
 
 	return (
 		<Dialog data-component="DeleteModal"
-			open
+			open={dialogOpen}
 			handler={handleCancel}
 			size="xs"
 			className="delete-modal rounded-md">

--- a/components/modals/common/HelpModal.jsx
+++ b/components/modals/common/HelpModal.jsx
@@ -6,12 +6,14 @@ import {
 	Typography,
 } from '@material-tailwind/react'
 import ModalCloseButton from '../../ui/ModalCloseButton'
+import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
 
 const HelpModal = ({ open, setHelpModal }) => {
 	const handleClose = () => setHelpModal(false)
+	const dialogOpen = useDelayedDialogOpen(open)
 
 	return (
-		<Dialog data-component="HelpModal" open={open} handler={handleClose} size="lg" className="rounded-md">
+		<Dialog data-component="HelpModal" open={dialogOpen} handler={handleClose} size="lg" className="rounded-md">
 			<DialogHeader className="justify-between gap-4">
 				<Typography variant="h2" color="blue" className="mt-0 mb-0">
 					Help and Documentation

--- a/components/modals/profile/UpdateEmailModal.jsx
+++ b/components/modals/profile/UpdateEmailModal.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'next-i18next'
 import { auth } from '../../../config/firebase'
 import FormInput from '../../ui/FormInput'
 import ModalCloseButton from '../../ui/ModalCloseButton'
+import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
 import {
 	Button,
 	Dialog,
@@ -13,11 +14,12 @@ import {
 } from '@material-tailwind/react'
 
 /**
- * Mount when visible (`{emailModal && <UpdateEmailModal ... />}`); Dialog is always open
- * while mounted, matching existing call sites.
+ * Mount when visible (`{emailModal && <UpdateEmailModal ... />}`); Dialog opens
+ * one tick later to avoid Floating UI aria-hidden warnings.
  */
 const UpdateEmailModal = ({ setEmailModal }) => {
 	const { t } = useTranslation('Profile')
+	const dialogOpen = useDelayedDialogOpen()
 
 	const { updateUserEmail } = useAuth()
 	const [updateSuccess, setUpdateSuccess] = useState(false)
@@ -48,7 +50,7 @@ const UpdateEmailModal = ({ setEmailModal }) => {
 
 	return (
 		<Dialog data-component="UpdateEmailModal"
-			open
+			open={dialogOpen}
 			handler={handleClose}
 			size="xs"
 			className="update-email-modal rounded-md">

--- a/components/modals/profile/UpdatePwModal.jsx
+++ b/components/modals/profile/UpdatePwModal.jsx
@@ -5,6 +5,7 @@ import { auth } from '../../../config/firebase'
 import { MdOutlineRemoveRedEye } from 'react-icons/md'
 import FormInput from '../../ui/FormInput'
 import ModalCloseButton from '../../ui/ModalCloseButton'
+import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
 import {
 	Button,
 	Dialog,
@@ -14,11 +15,12 @@ import {
 } from '@material-tailwind/react'
 
 /**
- * Mount when visible (`{openModal && <UpdatePwModal ... />}`); Dialog is always open
- * while mounted, matching existing call sites.
+ * Mount when visible (`{openModal && <UpdatePwModal ... />}`); Dialog opens one
+ * tick later to avoid Floating UI aria-hidden warnings.
  */
 const UpdatePwModal = ({ setOpenModal }) => {
 	const { t } = useTranslation('Profile')
+	const dialogOpen = useDelayedDialogOpen()
 
 	const { user, updateUserPassword } = useAuth()
 	const [updateSuccess, setUpdateSuccess] = useState(false)
@@ -54,7 +56,7 @@ const UpdatePwModal = ({ setOpenModal }) => {
 
 	return (
 		<Dialog data-component="UpdatePwModal"
-			open
+			open={dialogOpen}
 			handler={handleClose}
 			size="xs"
 			className="update-pw-modal rounded-md">

--- a/components/modals/reports/AgencyReportModal.jsx
+++ b/components/modals/reports/AgencyReportModal.jsx
@@ -1276,7 +1276,7 @@ const AgencyReportModal = ({
 						{hasFieldErrors && (
 							<div
 								role="alert"
-								className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+								className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
 								{t('formErrorsSummary', {
 									defaultValue:
 										'Please fix the highlighted fields below.',

--- a/components/modals/reports/AgencyReportModal.jsx
+++ b/components/modals/reports/AgencyReportModal.jsx
@@ -4,6 +4,7 @@ import ModalCloseButton from '../../ui/ModalCloseButton'
 import { useAuth } from '../../../context/AuthContext'
 import moment from 'moment'
 import { db } from '../../../config/firebase'
+import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
 import {
 	fetchExperimentConfig,
 	getActiveExperimentId,
@@ -141,6 +142,7 @@ const AgencyReportModal = ({
 	setNewReportModal,
 	handleNewReportSubmit,
 }) => {
+	const dialogOpen = useDelayedDialogOpen(open)
 	const dbInstance = collection(db, 'reports')
 	const { user, customClaims, refreshCustomClaims } = useAuth()
 	// useStates
@@ -1243,7 +1245,7 @@ const AgencyReportModal = ({
 	return (
 		<>
 			<Dialog data-component="AgencyReportModal"
-				open={open}
+				open={dialogOpen}
 				handler={handleNewReportModalClose}
 				size="xl"
 				className="agency-report-modal rounded-md"

--- a/components/modals/reports/ReportModal.jsx
+++ b/components/modals/reports/ReportModal.jsx
@@ -23,6 +23,7 @@
 
 import React, { useEffect, useState } from "react"
 import { resolveAgencyIdForReport } from '../../../utils/label-tags'
+import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
 import {
 	Button,
 	Dialog,
@@ -196,18 +197,11 @@ const ReportModal = ({
 	const [shareReportModal, setShareReportModal] = useState(false) // Share modal visibility
 	const [tagLabelMap, setTagLabelMap] = useState({})
 	const [lightboxOpen, setLightboxOpen] = useState(false)
-	// Delay Dialog open one tick: MT Dialog + Floating UI 0.19 logs aria-hidden
-	// "not contained inside body" when mounting with open={true} immediately.
-	const [dialogOpen, setDialogOpen] = useState(false)
+	const dialogOpen = useDelayedDialogOpen()
 
 	const reportImages = Array.isArray(report.images)
 		? report.images.filter(Boolean)
 		: []
-
-	useEffect(() => {
-		const id = window.setTimeout(() => setDialogOpen(true), 0)
-		return () => window.clearTimeout(id)
-	}, [])
 
 	useEffect(() => {
 		let cancelled = false

--- a/components/modals/tagging/EditLabelModal.jsx
+++ b/components/modals/tagging/EditLabelModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { CUSTOM_LABEL_DEFAULT_COLOR } from '../../../config/labels'
 import ModalCloseButton from '../../ui/ModalCloseButton'
+import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
 import {
 	Button,
 	Dialog,
@@ -13,7 +14,8 @@ import {
 /**
  * Modal for editing a custom label's color (name is read-only in v1).
  *
- * Mount when visible; Dialog is always open while mounted.
+ * Mount when visible; Dialog opens one tick later to avoid Floating UI
+ * aria-hidden warnings when mounting with open={true} immediately.
  *
  * @param {Object} props
  * @param {string} props.labelName
@@ -23,6 +25,7 @@ import {
  */
 const EditLabelModal = ({ labelName, currentColor, onSave, onClose }) => {
 	const [color, setColor] = useState(currentColor || CUSTOM_LABEL_DEFAULT_COLOR)
+	const dialogOpen = useDelayedDialogOpen()
 
 	const handleSave = (e) => {
 		e.preventDefault()
@@ -31,7 +34,7 @@ const EditLabelModal = ({ labelName, currentColor, onSave, onClose }) => {
 
 	return (
 		<Dialog data-component="EditLabelModal"
-			open
+			open={dialogOpen}
 			handler={onClose}
 			size="xs"
 			className="edit-label-modal rounded-md">

--- a/components/modals/tagging/NewLabelModal.jsx
+++ b/components/modals/tagging/NewLabelModal.jsx
@@ -5,6 +5,7 @@ import {
 } from '../../../config/labels'
 import FormInput from '../../ui/FormInput'
 import ModalCloseButton from '../../ui/ModalCloseButton'
+import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
 import {
 	Button,
 	Dialog,
@@ -17,7 +18,8 @@ import {
 /**
  * Modal for creating a new custom agency label from Tagging Systems.
  *
- * Mount when visible; Dialog is always open while mounted.
+ * Mount when visible; Dialog opens one tick later to avoid Floating UI
+ * aria-hidden warnings when mounting with open={true} immediately.
  *
  * @param {Object} props
  * @param {string[]} props.existingLabels
@@ -26,6 +28,7 @@ import {
  */
 const NewLabelModal = ({ existingLabels, onClose, onAdd }) => {
 	const [label, setLabel] = useState('')
+	const dialogOpen = useDelayedDialogOpen()
 	const existingLower = existingLabels.map((item) => item.toLowerCase())
 	const validationError = validateCustomLabel(label)
 	const isDuplicate =
@@ -40,7 +43,7 @@ const NewLabelModal = ({ existingLabels, onClose, onAdd }) => {
 
 	return (
 		<Dialog data-component="NewLabelModal"
-			open
+			open={dialogOpen}
 			handler={onClose}
 			size="xs"
 			className="new-label-modal rounded-md">

--- a/components/modals/tagging/NewTagModal.jsx
+++ b/components/modals/tagging/NewTagModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import FormInput from '../../ui/FormInput'
 import ModalCloseButton from '../../ui/ModalCloseButton'
+import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
 import {
 	Button,
 	Dialog,
@@ -19,7 +20,8 @@ import {
 /**
  * Modal to add a custom agency Topic/Source tag with EN id + EN/ES labels.
  *
- * Mount when visible; Dialog is always open while mounted.
+ * Mount when visible; Dialog opens one tick later to avoid Floating UI
+ * aria-hidden warnings when mounting with open={true} immediately.
  *
  * @param {{
  *   tagSystems: string[],
@@ -41,6 +43,7 @@ const NewTagModal = ({
 	const [labelEn, setLabelEn] = useState('')
 	const [labelEs, setLabelEs] = useState('')
 	const [error, setError] = useState('')
+	const dialogOpen = useDelayedDialogOpen()
 
 	const handleClose = () => setNewTagModal(false)
 
@@ -69,7 +72,7 @@ const NewTagModal = ({
 
 	return (
 		<Dialog data-component="NewTagModal"
-			open
+			open={dialogOpen}
 			handler={handleClose}
 			size="sm"
 			className="new-tag-modal rounded-md">

--- a/components/modals/tagging/RenameTagModal.jsx
+++ b/components/modals/tagging/RenameTagModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import FormInput from '../../ui/FormInput'
 import ModalCloseButton from '../../ui/ModalCloseButton'
+import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
 import {
 	Button,
 	Dialog,
@@ -19,7 +20,8 @@ import {
 /**
  * Modal to rename/edit a custom agency tag id and EN/ES labels.
  *
- * Mount when visible; Dialog is always open while mounted.
+ * Mount when visible; Dialog opens one tick later to avoid Floating UI
+ * aria-hidden warnings when mounting with open={true} immediately.
  *
  * @param {{
  *   replaceTag: (entry: { id: string, labels: { en: string, es: string } }) => void,
@@ -44,6 +46,7 @@ const RenameTagModal = ({
 	const [labelEn, setLabelEn] = useState(existingLabels?.en || selected || '')
 	const [labelEs, setLabelEs] = useState(existingLabels?.es || '')
 	const [error, setError] = useState('')
+	const dialogOpen = useDelayedDialogOpen()
 
 	const handleClose = () => setRenameTagModal(false)
 
@@ -78,7 +81,7 @@ const RenameTagModal = ({
 
 	return (
 		<Dialog data-component="RenameTagModal"
-			open
+			open={dialogOpen}
 			handler={handleClose}
 			size="sm"
 			className="rename-tag-modal rounded-md">

--- a/components/partials/modals/ShareReportModal.jsx
+++ b/components/partials/modals/ShareReportModal.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'next-i18next'
 import FormInput from '../../ui/FormInput'
 import ModalCloseButton from '../../ui/ModalCloseButton'
+import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
 import {
 	Button,
 	Dialog,
@@ -19,7 +20,8 @@ import {
 /**
  * Modal for sharing a report by email or by copying its dashboard link.
  *
- * Mount when visible; Dialog is always open while mounted.
+ * Mount when visible; Dialog opens one tick later to avoid Floating UI
+ * aria-hidden warnings when mounting with open={true} immediately.
  *
  * @param {Object} props
  * @param {string} props.reportId - Report document id used to build the share URL
@@ -31,6 +33,7 @@ const ShareReportModal = ({ reportId, reportTitle = '', closeModal }) => {
 	const [email, setEmail] = useState('')
 	const [copied, setCopied] = useState(false)
 	const [copyError, setCopyError] = useState(false)
+	const dialogOpen = useDelayedDialogOpen()
 	const shareUrl = buildReportShareUrl(reportId)
 
 	const handleClose = () => closeModal(false)
@@ -63,7 +66,7 @@ const ShareReportModal = ({ reportId, reportTitle = '', closeModal }) => {
 
 	return (
 		<Dialog data-component="ShareReportModal"
-			open
+			open={dialogOpen}
 			handler={handleClose}
 			size="xs"
 			className="share-report-modal rounded-md">

--- a/components/profile/AgencySettingsForm.jsx
+++ b/components/profile/AgencySettingsForm.jsx
@@ -61,7 +61,7 @@ const AgencySettingsForm = ({
     : 'No agency logo'
 
   return (
-    <section data-component="AgencySettingsForm" className="mb-8 p-6 bg-white rounded-lg border border-blue-gray-100">
+    <section data-component="AgencySettingsForm" className="mb-8 p-6 bg-white rounded-md border border-blue-gray-100">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <Typography variant="h2" className="mt-0 mb-0 text-brand">
           Agency Settings

--- a/components/reports/ReportList.jsx
+++ b/components/reports/ReportList.jsx
@@ -127,7 +127,7 @@ const ReportList = ({reportView, setReportView}) => {
     <div data-component="ReportList" className="contents">
       {/* Report List View (reportView === 0) */}
       {reportView == 0 &&
-        <ul className="bg-white p-4 rounded-lg mt-2 flex flex-col divide-y divide-gray-100">
+        <ul className="bg-white p-4 rounded-md mt-2 flex flex-col divide-y divide-gray-100">
           {reports.map((reportObj, i) => {
             const report = Object.values(reportObj)[0] // Extract report data
             const reportId = Object.keys(reportObj)[0] // Extract report ID
@@ -140,7 +140,7 @@ const ReportList = ({reportView, setReportView}) => {
               <li 
                 onClick={() => handleReportView(Object.keys(reportObj)[0])} 
                 key={i} 
-                className="flex gap-4 py-5 pl-4 text-left rounded-lg hover:bg-slate-100 cursor-pointer"
+                className="flex gap-4 py-5 pl-4 text-left rounded-md hover:bg-slate-100 cursor-pointer"
               >
                 <div>{posted}</div> {/* Display formatted date */}
                 <div>{report.title}</div> {/* Display report title */}

--- a/components/reports/ReportsSection.jsx
+++ b/components/reports/ReportsSection.jsx
@@ -1458,12 +1458,12 @@ const ReportsSection = ({
 						</div>
 					</div>
 					{agencyClaimsStatus === 'pending' && (
-						<div className="mb-3 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800">
+						<div className="mb-3 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800">
 							Loading agency access…
 						</div>
 					)}
 					{agencyClaimsStatus === 'missing' && (
-						<div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+						<div className="mb-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
 							Agency access is incomplete (missing agency ID on your account).
 							Refresh the page, or ask an admin to re-run agency claims backfill.
 						</div>

--- a/components/ui/FormSelect.jsx
+++ b/components/ui/FormSelect.jsx
@@ -29,10 +29,10 @@ const FormSelect = ({
       {label && (
         <label
           htmlFor={id}
-          className={`pointer-events-none absolute left-3 z-[1] bg-white px-1 transition-all duration-200 ${
+          className={`pointer-events-none absolute left-3 z-[1] bg-white px-1 font-normal transition-all duration-200 ${
             floated
-              ? '-top-2 text-[11px] leading-tight text-gray-900'
-              : 'top-2.5 text-sm text-blue-gray-500'
+              ? `-top-2 text-[11px] leading-tight ${focused ? 'text-gray-900' : 'text-gray-500'}`
+              : 'top-2.5 text-sm leading-tight text-blue-gray-500'
           }`}
         >
           {label}

--- a/components/ui/MediaUploadField.jsx
+++ b/components/ui/MediaUploadField.jsx
@@ -144,7 +144,7 @@ const MediaUploadField = ({
 				onDragOver={(event) => handleDrag(event, true)}
 				onDragLeave={(event) => handleDrag(event, false)}
 				onDrop={handleDrop}
-				className={`flex w-full items-center gap-2 rounded-lg border border-dashed px-3 py-2.5 text-left transition-colors ${
+				className={`flex w-full items-center gap-2 rounded-md border border-dashed px-3 py-2.5 text-left transition-colors ${
 					isDragging
 						? 'border-blue-500 bg-blue-50'
 						: 'border-slate-300 bg-white hover:border-blue-400 hover:bg-sky-50'

--- a/components/ui/formFieldStyles.js
+++ b/components/ui/formFieldStyles.js
@@ -63,42 +63,25 @@ export const FORM_CONTROL_FOCUS_BORDER_CLASS = [
 ].join(' ')
 
 /**
- * Keep outlined look when disabled — MT defaults to border-0 + gray fill.
- * Floated labels need a transparent top edge for the notch.
- */
-export const FORM_CONTROL_DISABLED_FIELD_CLASS = [
-  'disabled:!bg-white',
-  'disabled:!border',
-  'disabled:!border-blue-gray-200',
-  'disabled:placeholder-shown:!border-t-blue-gray-200',
-  'disabled:[&:not(:placeholder-shown)]:!border-t-transparent',
-].join(' ')
-
-/**
- * Keep floating label + notch visible when disabled — MT uses
- * peer-disabled:text-transparent and transparent notch borders.
+ * MT defaults hide the floated label when disabled (`peer-disabled:text-transparent`).
+ * Keep a muted label so User ID / Email stay identifiable, but clear the notch
+ * (::before / ::after) borders — disabled fields use border-0, so a notch looks wrong.
  */
 export const FORM_CONTROL_DISABLED_LABEL_CLASS = [
-  'peer-disabled:!text-blue-gray-400',
-  'peer-disabled:peer-placeholder-shown:!text-blue-gray-500',
-  'peer-disabled:before:!border-t',
-  'peer-disabled:before:!border-l',
-  'peer-disabled:before:!border-blue-gray-200',
-  'peer-disabled:after:!border-t',
-  'peer-disabled:after:!border-r',
-  'peer-disabled:after:!border-blue-gray-200',
-  'peer-disabled:peer-placeholder-shown:before:!border-transparent',
-  'peer-disabled:peer-placeholder-shown:after:!border-transparent',
+	'peer-disabled:!text-blue-gray-400',
+	'peer-disabled:before:!border-transparent',
+	'peer-disabled:after:!border-transparent',
 ].join(' ')
 
 export const FORM_CONTROL_FIELD_CLASS = [
   '!bg-white',
+  'disabled:!bg-blue-gray-50',
   '!shadow-none',
   'focus:!shadow-none',
   FORM_CONTROL_BORDER_WIDTH_CLASS,
+  'disabled:!border-0',
   FORM_CONTROL_FOCUS_BORDER_CLASS,
   FORM_CONTROL_PADDING_CLASS,
-  FORM_CONTROL_DISABLED_FIELD_CLASS,
 ].join(' ')
 
 /**

--- a/context/AuthContext.jsx
+++ b/context/AuthContext.jsx
@@ -508,21 +508,43 @@ export const AuthContextProvider = ({children}) => {
     }
     
     /**
-     * Sends a sign-in link to the specified email address.
-     * 
+     * Sends a passwordless sign-in / invite link to the given email.
+     * Optional agency fields are appended to the signup continue URL so the
+     * invitee can see which agency they are joining (association still comes
+     * from agencyUsers + addAgencyRole, not from these query params).
+     *
      * @param {string} email - Email address to send sign-in link to
+     * @param {{ agencyId?: string, agencyName?: string }} [agency]
      * @returns {Promise<void>} Resolves when email is sent
      * @throws {Error} When email sending fails
      * @example
-     * await sendSignIn('user@example.com');
+     * await sendSignIn('user@example.com', { agencyId: 'abc', agencyName: 'City PD' });
      */
-    const sendSignIn = async (email) => {
-        // Always use configured app URL so invites from localhost still point at the live app
+    const sendSignIn = async (email, agency = {}) => {
+        // Prefer the page origin on localhost so invite/signup testing hits local code.
+        // Production/hosted keeps NEXT_PUBLIC_APP_URL (or the App Hosting fallback).
+        const host =
+            typeof window !== 'undefined' ? window.location.hostname : ''
+        const isLocalHost =
+            host === 'localhost' || host === '127.0.0.1' || host === '[::1]'
         const origin = (
-            process.env.NEXT_PUBLIC_APP_URL ||
-            'https://truthsleuthlocal--misinfo-5d004.us-central1.hosted.app'
+            isLocalHost && typeof window !== 'undefined'
+                ? window.location.origin
+                : process.env.NEXT_PUBLIC_APP_URL ||
+                  'https://truthsleuthlocal--misinfo-5d004.us-central1.hosted.app'
         ).replace(/\/$/, '')
-        const baseUrl = `${origin}/signup`
+        const params = new URLSearchParams()
+        const agencyId =
+            typeof agency?.agencyId === 'string' ? agency.agencyId.trim() : ''
+        const agencyName =
+            typeof agency?.agencyName === 'string' ? agency.agencyName.trim() : ''
+        if (agencyId) params.set('agencyId', agencyId)
+        if (agencyName) params.set('agencyName', agencyName)
+        // Public invites (Users page) get an explicit marker so signup never
+        // treats them as agency just because the URL is an email link.
+        if (!agencyId && !agencyName) params.set('invite', 'user')
+        const qs = params.toString()
+        const baseUrl = `${origin}/signup${qs ? `?${qs}` : ''}`
 
         const actionCodeSettings = {
             url: baseUrl,
@@ -533,7 +555,7 @@ export const AuthContextProvider = ({children}) => {
             await sendSignInLinkToEmail(auth, email, actionCodeSettings)
             // Save the email locally for later use
             window.localStorage.setItem('emailForSignIn', email)
-            console.log("Sign-in link sent to:", email);
+            console.log("Sign-in link sent to:", email, 'continueUrl:', baseUrl);
         } catch (error) {
             const errorMessage = error.message
             console.error("Error sending sign-in link:", errorMessage);

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -128,6 +128,14 @@
         { "fieldPath": "experimentId", "order": "ASCENDING" },
         { "fieldPath": "origin", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "mobileUsers",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userRole", "order": "ASCENDING" },
+        { "fieldPath": "joiningDate", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -73,3 +73,4 @@ export function useReports() {
 
 // Export pagination hooks
 export { useUsersPagination, useUserDetailsBatch } from './useUsersPagination'
+export { useDelayedDialogOpen } from './useDelayedDialogOpen'

--- a/hooks/useDelayedDialogOpen.js
+++ b/hooks/useDelayedDialogOpen.js
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Delays Material Tailwind Dialog `open` by one tick so Floating UI 0.19
+ * does not log aria-hidden "not contained inside body" on open/mount.
+ *
+ * @param {boolean} [open=true] Controlled open prop, or omit when the modal is
+ *   only mounted while visible (treated as always open while mounted).
+ * @returns {boolean} Value to pass to Dialog's `open` prop
+ */
+export function useDelayedDialogOpen(open = true) {
+	const [dialogOpen, setDialogOpen] = useState(false)
+
+	useEffect(() => {
+		if (!open) {
+			setDialogOpen(false)
+			return
+		}
+		const id = window.setTimeout(() => setDialogOpen(true), 0)
+		return () => window.clearTimeout(id)
+	}, [open])
+
+	return dialogOpen
+}

--- a/hooks/useUsersPagination.jsx
+++ b/hooks/useUsersPagination.jsx
@@ -209,8 +209,8 @@ export function useUsersPagination({
       prevFilters.orderField !== orderField ||
       prevFilters.orderDirection !== orderDirection;
 
-    if (filtersChanged && users.length > 0) {
-      // Filters changed, reset pagination
+    if (filtersChanged) {
+      // Filters changed, reset pagination (including empty lists so new filters refetch)
       reset();
     }
 

--- a/pages/dashboard.jsx
+++ b/pages/dashboard.jsx
@@ -54,10 +54,11 @@ const VIEW_BY_TAB = [
  */
 function isTabAllowed(tabIndex, claims) {
 	if (tabIndex === 1) return true
-	if (tabIndex === 0 || tabIndex === 2 || tabIndex === 3) {
+	if (tabIndex === 0 || tabIndex === 2) {
 		return !!(claims.admin || claims.agency)
 	}
-	if (tabIndex === 4 || tabIndex === 5 || tabIndex === 6) {
+	// Users (3) and admin-only tools
+	if (tabIndex === 3 || tabIndex === 4 || tabIndex === 5 || tabIndex === 6) {
 		return !!claims.admin
 	}
 	return false
@@ -181,7 +182,7 @@ const Dashboard = () => {
 					{tab == 2 && (customClaims.admin || customClaims.agency) && (
 						<Settings customClaims={customClaims} />
 					)}
-					{tab == 3 && (customClaims.admin || customClaims.agency) && (
+					{tab == 3 && customClaims.admin && (
 						<Users customClaims={customClaims} />
 					)}
 					{tab == 4 && customClaims.admin && (

--- a/pages/dashboard/reports/[reportId].jsx
+++ b/pages/dashboard/reports/[reportId].jsx
@@ -273,7 +273,7 @@ const ReportDetails = () => {
 				</div>
 			</div>
 			{info?.archived === true && (
-				<div className="mb-4 px-4 py-2 rounded-lg bg-amber-100 text-amber-900 text-sm">
+				<div className="mb-4 px-4 py-2 rounded-md bg-amber-100 text-amber-900 text-sm">
 					This report is archived and hidden from default dashboard views.
 				</div>
 			)}

--- a/pages/signup.jsx
+++ b/pages/signup.jsx
@@ -24,9 +24,6 @@ import { useAuth } from '../context/AuthContext'
 import {
 	isSignInWithEmailLink,
 	signInWithEmailLink,
-	signOut,
-	createUserWithEmailAndPassword,
-	verifyEmail,
 } from 'firebase/auth'
 import {
 	doc,
@@ -70,10 +67,23 @@ const SignUp = () => {
 	const [errors, setErrors] = useState({})
 	
 	// Authentication context
-	const { user, signup, verifyEmail, addAgencyRole, setPassword } = useAuth()
+	const { signup, addAgencyRole, setPassword } = useAuth()
 	
-	// Check if current user has agency invitation privilege
-	const isAgency = isSignInWithEmailLink(auth, window.location.href)
+	// Email-link invites: agency when continue URL has agency context; otherwise public User
+	const isEmailLinkInvite = isSignInWithEmailLink(auth, window.location.href)
+
+	const inviteAgencyName = (() => {
+		const raw = router.query?.agencyName
+		const value = Array.isArray(raw) ? raw[0] : raw
+		return typeof value === 'string' ? value.trim() : ''
+	})()
+	const inviteAgencyId = (() => {
+		const raw = router.query?.agencyId
+		const value = Array.isArray(raw) ? raw[0] : raw
+		return typeof value === 'string' ? value.trim() : ''
+	})()
+	const isAgencyInvite =
+		isEmailLinkInvite && (!!inviteAgencyName || !!inviteAgencyId)
 	
 	// Form data state
 	const [data, setData] = useState({
@@ -101,32 +111,59 @@ const SignUp = () => {
 	 * @param {string} privilege - User role ('User', 'Agency', or 'Admin')
 	 * @returns {Promise<void>}
 	 */
-	const addMobileUser = (privilege) => {
-		// Get user object
-		// console.log('addMobileUser start', privilege)
-		const user = auth.currentUser
-		// console.log(user)
-		if (user) {
-			// Set user uid
-			// console.log('adding mobile user')
-			// console.log(data)
-			const uid = user.uid
-			// create a new mobileUsers doc with signed in user's uid
-			setDoc(doc(db, 'mobileUsers', uid), {
-				name: data.name,
-				email: data.email,
-				// phone: data.phone ? data.phone : '',
-				joiningDate: moment().utc().unix(),
-				state: data.state,
-				city: data.city,
-				isBanned: false,
-				userRole: privilege,
-				contact: data.contact,
-			})
-			// console.log("user was added with uid" + uid)
-		} else {
-			console.log('no user')
+	const addMobileUser = async (privilege) => {
+		const currentUser = auth.currentUser
+		if (!currentUser) {
+			throw new Error('No signed-in user to create profile for')
 		}
+		const uid = currentUser.uid
+		await setDoc(doc(db, 'mobileUsers', uid), {
+			name: data.name,
+			email: data.email,
+			joiningDate: moment().utc().unix(),
+			state: data.state,
+			city: data.city,
+			isBanned: false,
+			userRole: privilege,
+			contact: data.contact,
+		})
+	}
+
+	/**
+	 * Completes email-link signup: sign in, set password, write mobileUsers.
+	 * Agency role is optional and must not block profile creation.
+	 *
+	 * @param {'User' | 'Agency'} privilege
+	 * @param {{ assignAgencyRole?: boolean }} [options]
+	 */
+	const completeEmailLinkSignup = async (
+		privilege,
+		{ assignAgencyRole = false } = {},
+	) => {
+		const result = await signInWithEmailLink(
+			auth,
+			data.email,
+			window.location.href,
+		)
+		await auth.updateCurrentUser(result.user)
+		await auth.currentUser.reload()
+		await setPassword(data.password)
+
+		if (assignAgencyRole) {
+			try {
+				await addAgencyRole({
+					email: data.email,
+					...(inviteAgencyId ? { agencyId: inviteAgencyId } : {}),
+				})
+			} catch (roleErr) {
+				// Do not block mobileUsers creation — Auth account already exists.
+				console.error('addAgencyRole failed after signup:', roleErr)
+			}
+		}
+
+		await addMobileUser(privilege)
+		setSignUpError('')
+		window.location.replace('/verifyEmail')
 	}
 
 	/**
@@ -163,125 +200,54 @@ const SignUp = () => {
 			}
 		}
 		setErrors(allErrors)
-		// console.log("should be given agency privilege " + isAgency)
-		try {
-			if (isAgency) {
-				console.log('DEV LOG - handleSignUp - Agency user')
-				// Sees if agency already exists -if it does, adds user to the agency's user list
-				signInWithEmailLink(auth, data.email, window.location.href)
-					.then((result) => {
-						const promise2 = addAgencyRole({ email: data.email }) // Asynchronously adds agency role to the user.
-						const promise1 = auth.updateCurrentUser(result.user) // Updates the current user in Firebase.
-						auth.currentUser.reload().then(() => {
-							// Reloads the current user information.
-							const promise3 = setPassword(data.password) // Asynchronously sets the new password.
-							Promise.all([promise1, promise2, promise3]).then((values) => {
-								// Waits for all promises to complete.
-								/**
-                  Add new Agency issue is here. When the agency user goes through the
-                  signup process they are not added as a `mobileUser` and therefore
-                  they have no real profile
-                  -- or at least that is what my testing has shown.
-                  1) Admin user adds a new agency
-                  2) user's email is sent email subject:"Sign in to MisInfo App requested"
-                  3) user clicks link in email
-                  4) signup.jsx page with "** Must be the email you were sent the invite." text under Email input.
-                  5) user submits
-                  6) user's email is sent "Verify your email for MisInfo App"
-                  7) user clicks link
-                  8) verifyEmail.jsx page
-                  9) user clicks link
-                  10) https://misinfo-5d004.firebaseapp.com/__/auth/action?0000 page
-                  11) user clicks "Continue" button
-                  12) login.jsx page to log in
-                  notes: where is the user assigned the 'Agency' custom claim?
-                  notes: firestore `mobileUsers` db is not added the new user's doc
-                */
-								if (verifyEmail(auth.currentUser)) {
-									// console.log('verifyEmail==> ', verifyEmail(auth.currentUser));
-									// console.log('auth.currentUser==> ', auth.currentUser);
-									// Verifies the email of the logged-in user.
-									setSignUpError('') // Clears any previous sign-up errors.
-									addMobileUser('Agency') // Adds the user to the 'mobileUsers' collection with 'Agency' role.
-									window.location.replace('/verifyEmail') // Redirects to the verify email page.
-								} else {
-									// console.log("if in else where addMobileUser('Agency') runs")
-									addMobileUser('Agency')
-									// console.log('else SEND TO VERIFY EMAIL PAGE');
-									window.location.replace('/verifyEmail')
-								}
-							})
-						})
-					})
-					.catch((err) => {
-						if (err.message == 'Firebase: Error (auth/invalid-action-code).') {
-							setSignUpError(
-								'Sign in link had expired. Please ask admin to send a new link to sign up.',
-							)
-						} else if (
-							err.message ==
-							'Firebase: The email provided does not match the sign-in email address. (auth/invalid-email).'
-						) {
-							// An error happened.
-							setSignUpError(
-								'Your email does not match up with the email address that the sign-in link was sent to.',
-							)
-						} else {
-							console.log(err)
-						}
-					})
-				// const userCredential = await auth.currentUser.linkWithCredential(
-				// 	result.credential,
-				// )
-				// verifyEmail(auth.currentUser).then((verified) => {
-				// 	// Handle email verification logic
-				// 	// ...
-				// })
+		if (Object.keys(allErrors).length > 0) return
+
+		const handleEmailLinkError = (err) => {
+			if (err.message == 'Firebase: Error (auth/invalid-action-code).') {
+				setSignUpError(
+					'Sign in link had expired. Please ask admin to send a new link to sign up.',
+				)
+			} else if (
+				err.message ==
+				'Firebase: The email provided does not match the sign-in email address. (auth/invalid-email).'
+			) {
+				setSignUpError(
+					'Your email does not match up with the email address that the sign-in link was sent to.',
+				)
 			} else {
-				console.log('DEV LOG - handleSignUp - not agency user')
-
-				// check if `mobileUsers` doc already exist with the user's email
-				/*
-                try {
-                  console.log('NEW CODE--> ', data.email);
-                  const mobileRef = getDoc(doc(db, 'mobileUsers', data.email))
-                  // setUserData(mobileRef.data())
-                  console.log(mobileRef);
-                } catch (err) {
-                  if (err.message == "Firebase: Error (firestore 'mobileUsers' doc already created).") {
-                      setSignUpError("An account has already been set up with this email. Please log in.")
-                  } else {
-                      setSignUpError(err.message)
-                  }
-                }
-                */
-
-				signup(data.name, data.email, data.password, data.state, data.city)
-					.then((userCredential) => {
-						setSignUpError('')
-						addMobileUser('User')
-						router.push('/verifyEmail')
-						// console.log(
-						// 	'sign up successful user credentials--> ',
-						// 	userCredential,
-						// )
-					})
-					.catch((error) => {
-						if (error.code === 'auth/email-already-in-use') {
-							setSignUpError('The entered email is already in use.')
-						} else {
-							setSignUpError(error.message)
-						}
-						console.error('Error in (non Agency) signup--> ', error)
-					})
+				console.log(err)
+				setSignUpError(err.message)
 			}
-			// analytics.logEvent('sign_up', { method: 'email' }); // Log 'login' event
+		}
+
+		try {
+			if (isAgencyInvite) {
+				console.log('DEV LOG - handleSignUp - Agency invite')
+				await completeEmailLinkSignup('Agency', { assignAgencyRole: true })
+			} else if (isEmailLinkInvite) {
+				console.log('DEV LOG - handleSignUp - Public user invite')
+				await completeEmailLinkSignup('User')
+			} else {
+				console.log('DEV LOG - handleSignUp - self signup')
+
+				await signup(data.name, data.email, data.password, data.state, data.city)
+				setSignUpError('')
+				await addMobileUser('User')
+				router.push('/verifyEmail')
+			}
 		} catch (err) {
-			if (err.message == 'Firebase: Error (auth/email-already-in-use).') {
+			if (isEmailLinkInvite || isAgencyInvite) {
+				handleEmailLinkError(err)
+				return
+			}
+			if (err.code === 'auth/email-already-in-use') {
+				setSignUpError('The entered email is already in use.')
+			} else if (err.message == 'Firebase: Error (auth/email-already-in-use).') {
 				setSignUpError('Email already in use. Please log in.')
 			} else {
 				setSignUpError(err.message)
 			}
+			console.error('Error in signup--> ', err)
 		}
 	}
 	
@@ -358,9 +324,17 @@ const SignUp = () => {
 					
 					{/* Signup form */}
 					<form className="px-8 pt-6 pb-4 mb-4" onSubmit={handleSignUp}>
-						{/* Name input (hidden for agency users) */}
+						{isAgencyInvite && inviteAgencyName ? (
+							<div className="mb-4 rounded-md border border-blue-100 bg-blue-50 px-3 py-2">
+								<Typography variant="small" className="text-[#2E3B4E]">
+									You&apos;re joining{' '}
+									<span className="font-semibold">{inviteAgencyName}</span>
+								</Typography>
+							</div>
+						) : null}
+						{/* Name input (hidden for agency invites) */}
 						<div className="mb-4">
-							{!isAgency && (
+							{!isAgencyInvite && (
 								<FormInput
 									id="name"
 									type="text"
@@ -418,7 +392,7 @@ const SignUp = () => {
 						{/* Email input */}
 						<div className="mb-4">
 							<FormInput
-								className={isAgency ? 'mb-1' : ''}
+								className={isEmailLinkInvite ? 'mb-1' : ''}
 								id="email"
 								type="email"
 								label={t('email')}
@@ -427,7 +401,7 @@ const SignUp = () => {
 								onChange={handleChange}
 								autoComplete="email"
 							/>
-							{isAgency && (
+							{isEmailLinkInvite && (
 								<div className="mb-1 text-sm italic">
 									** Must be the email you were sent the invite.
 								</div>
@@ -436,14 +410,14 @@ const SignUp = () => {
 						
 						{/* Password input with visibility toggle */}
 						<>
-							{isAgency && (
+							{isEmailLinkInvite && (
 								<div className="mb-1 text-sm italic">
 									Create a secure password for your account.
 								</div>
 							)}
 							<div className="mb-1">
 								<FormInput
-									className={isAgency ? 'mb-1' : ''}
+									className={isEmailLinkInvite ? 'mb-1' : ''}
 									id="password"
 									type={type}
 									label={t('password')}

--- a/styles/style.js
+++ b/styles/style.js
@@ -173,11 +173,40 @@ const style = {
 	},
 	// Align panel radius with app containers (rounded-md). MT defaults:
 	// Dialog container → rounded-lg; Card → rounded-xl.
+	// Size tiers: replace MT % widths with w-full + hard max-w so wide
+	// viewports don't stretch lg/xl panels. xxl stays fullscreen (unused).
 	dialog: {
 		styles: {
 			base: {
 				container: {
 					borderRadius: 'rounded-md',
+				},
+			},
+			sizes: {
+				xs: {
+					width: 'w-full',
+					minWidth: 'min-w-0',
+					maxWidth: 'max-w-md',
+				},
+				sm: {
+					width: 'w-full',
+					minWidth: 'min-w-0',
+					maxWidth: 'max-w-lg',
+				},
+				md: {
+					width: 'w-full',
+					minWidth: 'min-w-0',
+					maxWidth: 'max-w-xl',
+				},
+				lg: {
+					width: 'w-full',
+					minWidth: 'min-w-0',
+					maxWidth: 'max-w-3xl',
+				},
+				xl: {
+					width: 'w-full',
+					minWidth: 'min-w-0',
+					maxWidth: 'max-w-5xl',
 				},
 			},
 		},

--- a/styles/style.js
+++ b/styles/style.js
@@ -150,12 +150,34 @@ const style = {
 			color: 'blue',
 		},
 		styles: {
+			base: {
+				input: {
+					// All colors (blue, red, …) — not only the brand override below
+					backgroundImage: 'checked:[background-image:none]',
+				},
+			},
 			colors: {
 				blue: {
 					input:
 						'checked:bg-brand checked:[background-image:none]',
 					circle: 'peer-checked:border-brand',
 					before: 'peer-checked:before:bg-brand',
+				},
+				red: {
+					input: 'checked:bg-red-500 checked:[background-image:none]',
+					circle: 'peer-checked:border-red-500',
+					before: 'peer-checked:before:bg-red-500',
+				},
+			},
+		},
+	},
+	// MT default text-blue-gray-500 is ~4.13:1 on white (fails WCAG AA for normal text).
+	// blue-gray-600 is ~5.1:1 and keeps the same muted body tone.
+	dialogBody: {
+		styles: {
+			base: {
+				initial: {
+					color: 'text-blue-gray-600',
 				},
 			},
 		},

--- a/styles/style.js
+++ b/styles/style.js
@@ -171,6 +171,26 @@ const style = {
 			},
 		},
 	},
+	// Align panel radius with app containers (rounded-md). MT defaults:
+	// Dialog container → rounded-lg; Card → rounded-xl.
+	dialog: {
+		styles: {
+			base: {
+				container: {
+					borderRadius: 'rounded-md',
+				},
+			},
+		},
+	},
+	card: {
+		styles: {
+			base: {
+				initial: {
+					borderRadius: 'rounded-md',
+				},
+			},
+		},
+	},
 	// MT default text-blue-gray-500 is ~4.13:1 on white (fails WCAG AA for normal text).
 	// blue-gray-600 is ~5.1:1 and keeps the same muted body tone.
 	dialogBody: {

--- a/styles/style.js
+++ b/styles/style.js
@@ -143,6 +143,8 @@ const style = {
 		},
 	},
 	// Switch reads theme.switch (the package exports this key as switchButton).
+	// Hide @tailwindcss/forms checked ✓ — Switch is a checkbox under the hood;
+	// forms paints a white checkmark onto the track. Checkboxes keep their icon.
 	switch: {
 		defaultProps: {
 			color: 'blue',
@@ -150,7 +152,8 @@ const style = {
 		styles: {
 			colors: {
 				blue: {
-					input: 'checked:bg-brand',
+					input:
+						'checked:bg-brand checked:[background-image:none]',
 					circle: 'peer-checked:border-brand',
 					before: 'peer-checked:before:bg-brand',
 				},

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,6 +31,12 @@ module.exports = withMT({
 					100: '#e0f2fe',
 				},
 			},
+			fontSize: {
+				base: [
+					'14px', 
+					{ lineHeight: '1.5' }
+				],
+			},
 		},
 	},
 	plugins: [require("@tailwindcss/forms")],


### PR DESCRIPTION
## Summary
- Rebuild the admin **Users** view on Material Tailwind (card, sticky headers, dynamic height, role filter tabs, search, join-date sorting, agency membership display) and expand **EditUserModal** / **NewUserModal** UX.
- Add a `mobileUsers` Firestore composite index (`userRole` + `joiningDate`) to support filtered/sorted queries.
- Improve invite/signup flow: agency context on sign-in links, localhost continue URLs for local testing, and clearer public-invite handling.
- Design system polish: shared `rounded-md` on cards/dialogs/containers, dialog size max-width tiers (`xs`→`md` … `xl`→`5xl`), Switch theme fixes, and `useDelayedDialogOpen` across modals to avoid Floating UI aria-hidden warnings.

## Test plan
- [ ] Admin Users: load list, role tabs, search, sort by join date, open/edit/delete/disable flows
- [ ] Edit user: role, agency, banned, field saves; switches look correct (no forms checkmark on track)
- [ ] New user invite email: continue URL includes expected query params; signup completes for agency vs public invite
- [ ] Localhost invite uses page origin; hosted still uses `NEXT_PUBLIC_APP_URL`
- [ ] Spot-check modals (confirm, help, report, agency) for `rounded-md` and size caps on a wide viewport
- [ ] Deploy/confirm Firestore index for `mobileUsers` (`userRole` + `joiningDate`) if not already live