### PR TITLE
Use ImageLightboxGallery for Storage images in admin modals

### DIFF
--- a/components/layout/Navbar.jsx
+++ b/components/layout/Navbar.jsx
@@ -44,7 +44,6 @@ import BrandLockup, { BrandMark } from './BrandLockup'
 import {
 	NAV_COLLAPSED_WIDTH,
 	NAV_DESKTOP_MIN_WIDTH,
-	NAV_EXPANDED_MAX_WIDTH,
 	getMobileDrawerSize,
 	useMobileNav,
 } from '../../context/MobileNavContext'
@@ -181,6 +180,8 @@ const Navbar = ({
 		closeDrawer,
 		desktopExpanded,
 		toggleDesktopExpanded,
+		drawerWidth,
+		measuredExpandedWidth,
 		setMeasuredDrawerWidth,
 	} = useMobileNav()
 
@@ -189,10 +190,12 @@ const Navbar = ({
 	const isDesktop = windowSize[0] >= NAV_DESKTOP_MIN_WIDTH
 	// Mobile drawer is always labeled; never flip to icon-rail while closing (avoids CTA flash).
 	const showLabels = isDesktop ? desktopExpanded : true
-	// Mobile closed must be 0 — collapsed width + labels lets "Log out" peek past the off-screen transform.
+	// Desktop expanded size must match the measured content width (not the 280 cap).
+	// Using the cap while `!w-max` is on makes collapse pop: dropping `!w-max` snaps
+	// w-full up to maxWidth (280) before the 280→65 transition runs.
 	const drawerSize = isDesktop
 		? showLabels
-			? NAV_EXPANDED_MAX_WIDTH
+			? drawerWidth
 			: NAV_COLLAPSED_WIDTH
 		: open
 			? getMobileDrawerSize(windowSize[0])
@@ -221,6 +224,12 @@ const Navbar = ({
 
 		const report = () => {
 			const width = el.getBoundingClientRect().width
+			const maxW = parseFloat(window.getComputedStyle(el).maxWidth)
+			if (!Number.isFinite(width) || !Number.isFinite(maxW)) return
+			// Skip mid max-width transition frames (fractional maxWidth) so we don't
+			// overwrite the stable expanded measurement with collapse/expand in-betweens.
+			if (Math.abs(maxW - Math.round(maxW)) > 0.1) return
+			if (width <= NAV_COLLAPSED_WIDTH + 1) return
 			setMeasuredDrawerWidth(width)
 		}
 		report()
@@ -491,7 +500,11 @@ const Navbar = ({
 				size={drawerSize}
 				overlay={disableOverlay}
 				className={`z-[9997] !h-full overflow-hidden transition-[max-width] duration-200 ease-in-out${
-					isDesktop && showLabels ? ' !w-max' : ''
+					// Content-size only until first measure; afterward size tracks width so
+					// collapse animates from the real width without a 280px snap.
+					isDesktop && showLabels && measuredExpandedWidth == null
+						? ' !w-max'
+						: ''
 				}`}>
 				<div
 					data-component="Navbar"

--- a/components/modals/HelpRequestsModal.jsx
+++ b/components/modals/HelpRequestsModal.jsx
@@ -6,10 +6,10 @@ import {
 	DialogHeader,
 	Typography,
 } from '@material-tailwind/react'
-import Image from 'next/image'
 import Link from 'next/link'
-import React, { Fragment } from 'react'
+import React, { Fragment, useState } from 'react'
 import ModalCloseButton from '../ui/ModalCloseButton'
+import ImageLightboxGallery from '../ui/ImageLightboxGallery'
 import { useDelayedDialogOpen } from '../../hooks/useDelayedDialogOpen'
 
 const formatLabel = (label) => label.replace(/([a-z])([A-Z])/g, '$1 $2')
@@ -20,13 +20,18 @@ const formatLabel = (label) => label.replace(/([a-z])([A-Z])/g, '$1 $2')
  */
 const HelpRequestsModal = ({ helpRequestInfo, handleClose, mailtoLink }) => {
 	const dialogOpen = useDelayedDialogOpen()
+	const [lightboxOpen, setLightboxOpen] = useState(false)
 
 	return (
 		<Dialog data-component="HelpRequestsModal"
 			open={dialogOpen}
 			handler={handleClose}
 			size="lg"
-			className="help-requests-modal rounded-md">
+			className="help-requests-modal rounded-md"
+			dismiss={{
+				escapeKey: !lightboxOpen,
+				outsidePress: () => !lightboxOpen,
+			}}>
 			<DialogHeader className="justify-between gap-4">
 				<Typography variant="h3" color="blue" className="mt-0 mb-0">
 					Help Request Info
@@ -45,25 +50,12 @@ const HelpRequestsModal = ({ helpRequestInfo, handleClose, mailtoLink }) => {
 							</Typography>
 							<div className="mb-4">
 								{key === 'images' ? (
-									<div className="grid grid-cols-1 gap-y-4">
-										{(Array.isArray(value) ? value : [value]).map(
-											(image, imgIndex) => (
-												<Link
-													key={imgIndex}
-													href={image}
-													passHref={true}
-													target="_blank">
-													<Image
-														src={`${image}`}
-														width={100}
-														height={100}
-														className="w-auto"
-														alt={`image-${imgIndex}`}
-													/>
-												</Link>
-											),
-										)}
-									</div>
+									<ImageLightboxGallery
+										images={Array.isArray(value) ? value : [value]}
+										altPrefix="Help request screenshot"
+										listClassName="grid grid-cols-2 gap-4 w-full sm:grid-cols-3"
+										onLightboxChange={setLightboxOpen}
+									/>
 								) : key === 'email' ? (
 									<Link href={mailtoLink} target="_blank" className="underline">
 										{value}

--- a/components/modals/__tests__/HelpRequestsModal.test.jsx
+++ b/components/modals/__tests__/HelpRequestsModal.test.jsx
@@ -1,0 +1,30 @@
+/**
+ * @fileoverview Smoke test: help request screenshots use ImageLightboxGallery.
+ */
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import HelpRequestsModal from '../HelpRequestsModal'
+
+describe('HelpRequestsModal', () => {
+	it('renders ImageLightboxGallery for stored screenshots', async () => {
+		render(
+			<HelpRequestsModal
+				helpRequestInfo={{
+					name: 'Ada',
+					email: 'ada@example.com',
+					images: ['https://example.com/shot.png'],
+				}}
+				handleClose={() => {}}
+				mailtoLink="mailto:ada@example.com"
+			/>,
+		)
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole('button', {
+					name: 'View help request screenshot 1',
+				}),
+			).toBeInTheDocument()
+		})
+	})
+})

--- a/components/modals/admin/AgencyModal.jsx
+++ b/components/modals/admin/AgencyModal.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
 import { IoClose } from 'react-icons/io5'
-import Image from 'next/image'
 import ConfirmModal from '../common/ConfirmModal'
 import FormInput from '../../ui/FormInput'
+import ImageLightboxGallery from '../../ui/ImageLightboxGallery'
 import MediaUploadField from '../../ui/MediaUploadField'
 import ModalCloseButton from '../../ui/ModalCloseButton'
 import { useDelayedDialogOpen } from '../../../hooks/useDelayedDialogOpen'
@@ -39,9 +39,14 @@ const AgencyModal = ({
 }) => {
 	const [deleteModal, setDeleteModal] = useState(false)
 	const [selectedUserToDelete, setSelectedUserToDelete] = useState('')
+	const [lightboxOpen, setLightboxOpen] = useState(false)
 	const dialogOpen = useDelayedDialogOpen()
 
 	const handleClose = () => setAgencyModal(false)
+
+	const logoImages = [
+		uploadedImageURLs[0] || agencyInfo.logo?.[0],
+	].filter(Boolean)
 
 	const handleDeleteClick = (user, e) => {
 		if (e) {
@@ -65,9 +70,9 @@ const AgencyModal = ({
 				size="xl"
 				className="agency-modal rounded-md"
 				dismiss={{
-					escapeKey: !deleteModal,
+					escapeKey: !deleteModal && !lightboxOpen,
 					outsidePress: (event) => {
-						if (deleteModal) return false
+						if (deleteModal || lightboxOpen) return false
 						const target = event.target
 						if (!(target instanceof Element)) return true
 						if (target.closest('.confirm-modal-root')) return false
@@ -153,25 +158,16 @@ const AgencyModal = ({
 								)}
 							</div>
 							<div>
-								{images.length === 0 && (
-									<>
-										{uploadedImageURLs[0] ? (
-											<Image
-												src={uploadedImageURLs[0]}
-												width={100}
-												height={100}
-												alt="Agency logo preview"
-												onLoad={() => URL.revokeObjectURL(uploadedImageURLs[0])}
-											/>
-										) : agencyInfo.logo?.[0] ? (
-											<Image
-												src={agencyInfo.logo[0]}
-												width={100}
-												height={100}
-												alt="Agency logo"
-											/>
-										) : null}
-									</>
+								{images.length === 0 && logoImages.length > 0 && (
+									<div className="mb-3 max-w-[7.5rem]">
+										<ImageLightboxGallery
+											images={logoImages}
+											altPrefix="Agency logo"
+											listClassName="grid grid-cols-1 gap-2 w-full"
+											thumbnailClassName="h-auto w-full max-w-[100px] object-contain"
+											onLightboxChange={setLightboxOpen}
+										/>
+									</div>
 								)}
 								<MediaUploadField
 									id="agency_logo_file"

--- a/components/ui/__tests__/ImageLightboxGallery.test.jsx
+++ b/components/ui/__tests__/ImageLightboxGallery.test.jsx
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Smoke tests for ImageLightboxGallery thumbnails + lightbox open.
+ */
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import ImageLightboxGallery from '../ImageLightboxGallery'
+
+describe('ImageLightboxGallery', () => {
+	it('renders nothing when images is empty', () => {
+		const { container } = render(<ImageLightboxGallery images={[]} />)
+		expect(container).toBeEmptyDOMElement()
+	})
+
+	it('opens a lightbox when a thumbnail is clicked', () => {
+		render(
+			<ImageLightboxGallery
+				images={['https://example.com/a.png', 'https://example.com/b.png']}
+				altPrefix="Report image"
+			/>,
+		)
+
+		fireEvent.click(
+			screen.getByRole('button', { name: 'View report image 1' }),
+		)
+
+		expect(
+			screen.getByRole('dialog', { name: 'Report image 1' }),
+		).toBeInTheDocument()
+		expect(screen.getByText('1 / 2')).toBeInTheDocument()
+	})
+})

--- a/context/MobileNavContext.jsx
+++ b/context/MobileNavContext.jsx
@@ -85,6 +85,7 @@ export function MobileNavProvider({ children }) {
 			desktopExpanded,
 			toggleDesktopExpanded,
 			drawerWidth,
+			measuredExpandedWidth,
 			setMeasuredDrawerWidth,
 		}),
 		[
@@ -94,6 +95,7 @@ export function MobileNavProvider({ children }) {
 			desktopExpanded,
 			toggleDesktopExpanded,
 			drawerWidth,
+			measuredExpandedWidth,
 			setMeasuredDrawerWidth,
 		],
 	)
@@ -114,6 +116,7 @@ export function useMobileNav() {
 			desktopExpanded: false,
 			toggleDesktopExpanded: () => {},
 			drawerWidth: NAV_COLLAPSED_WIDTH,
+			measuredExpandedWidth: null,
 			setMeasuredDrawerWidth: () => {},
 		}
 	}


### PR DESCRIPTION
## Summary
- Open Firebase Storage images in a lightbox in Help Requests and Agency modals (same pattern as ReportModal)
- Fix desktop nav drawer collapse snap by sizing from the measured content width
- Add smoke tests for ImageLightboxGallery and HelpRequestsModal

## Test plan
- [ ] Open an agency from Admin → Agencies; click the logo and confirm lightbox opens/closes (Esc, backdrop)
- [ ] Open a help request with screenshots; click a thumb and confirm lightbox (not a new tab)
- [ ] Confirm Esc/outside click does not close the parent modal while the lightbox is open
- [ ] Desktop: expand nav, then collapse — width should animate from the real expanded size without a 280px snap