### PR TITLE
Add admin Pipeline component and related functionality

### DIFF
--- a/components/admin/Pipeline.jsx
+++ b/components/admin/Pipeline.jsx
@@ -1,0 +1,357 @@
+/**
+ * Admin Pipeline tab — recent Truth Sleuth run health plus Data Studio.
+ *
+ * Shows a BigQuery rundown of nightly jobs, then embeds the articles report.
+ * The tab is Firebase-admin only; the iframe still needs a Google account
+ * that can open the Data Studio report.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { Button } from '@material-tailwind/react'
+import PageTitle from '../layout/PageTitle'
+import AdminDataTable from './AdminDataTable'
+import LoadingSpinner from '../ui/LoadingSpinner'
+import adminSectionStyles from '../../styles/adminSectionStyles'
+import { fetchPipelineRuns } from '../../utils/fetch-pipeline-runs'
+import {
+	DATA_STUDIO_EMBED_SANDBOX,
+	DATA_STUDIO_EMBED_SRC,
+	FUNNEL_STAGES,
+	formatCount,
+	formatDuration,
+	formatHealth,
+	formatIssueMessage,
+	formatRunTimestamp,
+	healthBadgeClass,
+	parseJsonArray,
+	pipelineRunKey,
+} from '../../utils/pipeline-runs'
+
+const style = adminSectionStyles
+
+const RUN_COLUMNS = [
+	'Night',
+	'Run ID',
+	'Health',
+	'Duration',
+	'Links',
+	'Extracted',
+	'Election',
+	'Geo',
+	'Curated',
+	'Dashboard',
+]
+
+/**
+ * @param {unknown} err
+ * @returns {string}
+ */
+function formatFetchError(err) {
+	if (typeof err === 'object' && err !== null) {
+		const e = /** @type {{ details?: unknown, message?: string }} */ (err)
+		if (typeof e.details === 'string' && e.details.trim()) return e.details
+		if (e.message && e.message !== 'INTERNAL') return e.message
+	}
+	return 'Failed to load pipeline runs.'
+}
+
+/**
+ * @param {Record<string, unknown>} run
+ */
+function HealthBadge({ run }) {
+	const label = formatHealth(run.health_status)
+	return (
+		<span
+			className={`inline-flex rounded-full px-2 py-0.5 text-xs font-semibold capitalize ${healthBadgeClass(
+				run.health_status,
+			)}`}>
+			{label}
+		</span>
+	)
+}
+
+/**
+ * @param {{ fetchRuns?: typeof fetchPipelineRuns }} props
+ */
+const Pipeline = ({ fetchRuns = fetchPipelineRuns }) => {
+	const [runs, setRuns] = useState([])
+	const [loading, setLoading] = useState(true)
+	const [error, setError] = useState('')
+	const [selectedKey, setSelectedKey] = useState('')
+
+	const loadRuns = useCallback(async () => {
+		setLoading(true)
+		setError('')
+		try {
+			const next = await fetchRuns(20)
+			setRuns(next)
+			setSelectedKey((prev) => {
+				if (prev && next.some((run, index) => pipelineRunKey(run, index) === prev)) {
+					return prev
+				}
+				return next.length ? pipelineRunKey(next[0], 0) : ''
+			})
+		} catch (err) {
+			console.error(err)
+			setRuns([])
+			setSelectedKey('')
+			setError(formatFetchError(err))
+		} finally {
+			setLoading(false)
+		}
+	}, [fetchRuns])
+
+	useEffect(() => {
+		loadRuns()
+	}, [loadRuns])
+
+	const selectedRun = useMemo(
+		() =>
+			runs.find((run, index) => pipelineRunKey(run, index) === selectedKey) ||
+			null,
+		[runs, selectedKey],
+	)
+
+	const latest = runs[0] || null
+	const issues = parseJsonArray(selectedRun?.issues_json)
+	const steps = parseJsonArray(selectedRun?.steps_completed_json)
+
+	return (
+		<div data-component="Pipeline" className={style.section_container}>
+			<div className={style.section_wrapper}>
+				<div className={style.section_header}>
+					<PageTitle gutter={false}>Pipeline</PageTitle>
+					<Button
+						size="sm"
+						color="blue"
+						variant="outlined"
+						onClick={loadRuns}
+						disabled={loading}>
+						Refresh
+					</Button>
+				</div>
+
+				<p className="mb-4 text-sm text-gray-600">
+					Nightly Truth Sleuth job health. The report below still signs in
+					with a Google account that can open Data Studio — dashboard admin
+					login does not unlock it.
+				</p>
+
+				{loading && (
+					<div className="flex items-center gap-3 py-8 text-sm text-gray-600">
+						<LoadingSpinner className="h-8 w-8 text-[#2E3B4E]" />
+						Loading recent runs…
+					</div>
+				)}
+
+				{!loading && error && (
+					<p className="mb-4 text-sm text-red-700" role="alert">
+						{error}
+					</p>
+				)}
+
+				{!loading && !error && latest && (
+					<div className="mb-6 grid grid-cols-2 gap-3 md:grid-cols-4">
+						<div className="rounded-md border border-blue-gray-100 bg-white p-4">
+							<p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+								Latest health
+							</p>
+							<div className="mt-2">
+								<HealthBadge run={latest} />
+							</div>
+							<p className="mt-2 text-xs text-gray-500">
+								{formatRunTimestamp(latest.run_timestamp)}
+							</p>
+						</div>
+						<div className="rounded-md border border-blue-gray-100 bg-white p-4">
+							<p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+								Duration
+							</p>
+							<p className="mt-2 text-lg font-semibold text-[#2E3B4E]">
+								{formatDuration(latest.duration_seconds)}
+							</p>
+						</div>
+						<div className="rounded-md border border-blue-gray-100 bg-white p-4">
+							<p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+								Dashboard articles
+							</p>
+							<p className="mt-2 text-lg font-semibold text-[#2E3B4E]">
+								{formatCount(latest.dashboard_rows)}
+							</p>
+						</div>
+						<div className="rounded-md border border-blue-gray-100 bg-white p-4">
+							<p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+								Curated
+							</p>
+							<p className="mt-2 text-lg font-semibold text-[#2E3B4E]">
+								{formatCount(latest.curated_rows)}
+							</p>
+						</div>
+					</div>
+				)}
+
+				{!loading && !error && latest && (
+					<div className="mb-6 flex flex-wrap gap-2">
+						{FUNNEL_STAGES.map((stage) => (
+							<div
+								key={stage.key}
+								className="rounded-md bg-slate-100 px-3 py-2 text-sm">
+								<span className="text-gray-500">{stage.label}: </span>
+								<span className="font-semibold text-[#2E3B4E]">
+									{formatCount(latest[stage.key])}
+								</span>
+							</div>
+						))}
+					</div>
+				)}
+
+				{!loading && !error && (
+					<div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+						<div className="min-w-0 max-h-[550px] overflow-auto rounded-md bg-white lg:w-3/4 [&_thead]:sticky [&_thead]:top-0 [&_thead]:z-10">
+							<AdminDataTable columns={RUN_COLUMNS}>
+								{runs.length === 0 && (
+									<tr>
+										<td
+											colSpan={RUN_COLUMNS.length}
+											className={`${style.table_td} text-center`}>
+											No pipeline runs found.
+										</td>
+									</tr>
+								)}
+								{runs.map((run, index) => {
+									const key = pipelineRunKey(run, index)
+									const isSelected = key === selectedKey
+									return (
+										<tr
+											key={key}
+											className={`${style.table_tr} ${
+												isSelected ? 'bg-indigo-50' : ''
+											}`}
+											onClick={() => setSelectedKey(key)}
+											aria-selected={isSelected}>
+											<td className={style.table_td}>
+												{formatRunTimestamp(run.run_timestamp)}
+											</td>
+											<td className={style.table_td}>
+												{run.measurement_run_id || '—'}
+											</td>
+											<td className={style.table_td}>
+												<HealthBadge run={run} />
+											</td>
+											<td className={style.table_td}>
+												{formatDuration(run.duration_seconds)}
+											</td>
+											<td className={style.table_td}>
+												{formatCount(run.links_rows)}
+											</td>
+											<td className={style.table_td}>
+												{formatCount(run.extracted_rows)}
+											</td>
+											<td className={style.table_td}>
+												{formatCount(run.election_rows)}
+											</td>
+											<td className={style.table_td}>
+												{formatCount(run.geographic_rows)}
+											</td>
+											<td className={style.table_td}>
+												{formatCount(run.curated_rows)}
+											</td>
+											<td className={style.table_td}>
+												{formatCount(run.dashboard_rows)}
+											</td>
+										</tr>
+									)
+								})}
+							</AdminDataTable>
+						</div>
+
+						{selectedRun && (
+							<aside className="flex w-full flex-col gap-3 rounded-md border border-blue-gray-100 bg-white p-4 lg:w-1/4">
+								<h2 className="text-lg font-semibold text-[#2E3B4E]">
+									Run details
+								</h2>
+								<dl className="flex flex-col gap-3 text-sm">
+									<div>
+										<dt className="text-gray-500">Run ID</dt>
+										<dd className="break-words font-medium text-[#2E3B4E]">
+											{selectedRun.measurement_run_id || '—'}
+										</dd>
+									</div>
+									<div>
+										<dt className="text-gray-500">Execution</dt>
+										<dd className="break-words font-medium text-[#2E3B4E]">
+											{selectedRun.execution_name || '—'}
+										</dd>
+									</div>
+									<div>
+										<dt className="text-gray-500">Image tag</dt>
+										<dd className="break-words font-medium text-[#2E3B4E]">
+											{selectedRun.image_tag || '—'}
+										</dd>
+									</div>
+									<div>
+										<dt className="text-gray-500">Classifier mode</dt>
+										<dd className="break-words font-medium text-[#2E3B4E]">
+											{selectedRun.election_classifier_mode || '—'}
+										</dd>
+									</div>
+									<div>
+										<dt className="text-gray-500">Pipeline status</dt>
+										<dd className="break-words font-medium text-[#2E3B4E]">
+											{selectedRun.pipeline_status || '—'}
+										</dd>
+									</div>
+									<div>
+										<dt className="text-gray-500">Night</dt>
+										<dd className="font-medium text-[#2E3B4E]">
+											{formatRunTimestamp(selectedRun.run_timestamp)}
+										</dd>
+									</div>
+									<div>
+										<dt className="text-gray-500">Steps completed</dt>
+										<dd className="break-words text-[#2E3B4E]">
+											{steps.length ? steps.map(String).join(', ') : '—'}
+										</dd>
+									</div>
+									<div>
+										<dt className="text-gray-500">Issues</dt>
+										<dd>
+											{issues.length === 0 ? (
+												<p className="text-[#2E3B4E]">None recorded.</p>
+											) : (
+												<ul className="mt-1 list-disc pl-5 text-[#2E3B4E]">
+													{issues.map((issue, index) => (
+														<li
+															key={`${formatIssueMessage(issue)}-${index}`}>
+															{formatIssueMessage(issue) ||
+																'Unnamed issue'}
+														</li>
+													))}
+												</ul>
+											)}
+										</dd>
+									</div>
+								</dl>
+							</aside>
+						)}
+					</div>
+				)}
+
+				<div className="mt-8">
+					<h2 className="mb-2 text-lg font-semibold text-[#2E3B4E]">
+						Data Studio
+					</h2>
+					<iframe
+						title="Truth Sleuth Data Studio articles report"
+						src={DATA_STUDIO_EMBED_SRC}
+						sandbox={DATA_STUDIO_EMBED_SANDBOX}
+						allowFullScreen
+						className="h-[900px] w-full rounded-md border-0 bg-white"
+					/>
+				</div>
+			</div>
+		</div>
+	)
+}
+
+export default Pipeline

--- a/components/admin/__tests__/Pipeline.test.jsx
+++ b/components/admin/__tests__/Pipeline.test.jsx
@@ -1,0 +1,79 @@
+/**
+ * Smoke tests for the admin Pipeline rundown + Data Studio embed.
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { ThemeProvider } from '@material-tailwind/react'
+import Pipeline from '../Pipeline'
+import { DATA_STUDIO_EMBED_SRC } from '../../../utils/pipeline-runs'
+
+jest.mock('../../../utils/fetch-pipeline-runs', () => ({
+	fetchPipelineRuns: jest.fn().mockResolvedValue([]),
+}))
+
+const sampleRun = {
+	run_timestamp: '20260811_070316',
+	measurement_run_id: 'production_daily',
+	health_status: 'ok',
+	duration_seconds: 3720,
+	links_rows: 1000,
+	extracted_rows: 800,
+	election_rows: 120,
+	geographic_rows: 40,
+	clustered_rows: 30,
+	curated_rows: 12,
+	dashboard_rows: 12,
+	execution_name: 'truth-sleuth-test-abc',
+	image_tag: 'sha-123',
+	election_classifier_mode: 'bert_primary',
+	pipeline_status: 'success',
+	issues_json: '[]',
+	steps_completed_json: '["link_collection","content_extraction"]',
+}
+
+function renderPipeline(fetchRuns) {
+	return render(
+		<ThemeProvider>
+			<Pipeline fetchRuns={fetchRuns} />
+		</ThemeProvider>,
+	)
+}
+
+describe('Pipeline', () => {
+	it('renders the title, rundown, and Data Studio embed', async () => {
+		const fetchRuns = jest.fn().mockResolvedValue([sampleRun])
+		renderPipeline(fetchRuns)
+
+		expect(
+			screen.getByRole('heading', { level: 1, name: 'Pipeline' }),
+		).toBeInTheDocument()
+
+		expect(
+			await screen.findByRole('heading', { name: 'Run details' }),
+		).toBeInTheDocument()
+		expect(screen.getAllByText('production_daily').length).toBeGreaterThan(0)
+		expect(screen.getAllByText('1h 2m').length).toBeGreaterThan(0)
+		expect(screen.getByText('truth-sleuth-test-abc')).toBeInTheDocument()
+
+		const iframe = screen.getByTitle(
+			'Truth Sleuth Data Studio articles report',
+		)
+		expect(iframe).toHaveAttribute('src', DATA_STUDIO_EMBED_SRC)
+	})
+
+	it('shows an error when the rundown fails to load', async () => {
+		const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+		const fetchRuns = jest
+			.fn()
+			.mockRejectedValue(new Error('Admin privileges required.'))
+		renderPipeline(fetchRuns)
+
+		expect(await screen.findByRole('alert')).toHaveTextContent(
+			'Admin privileges required.',
+		)
+		expect(
+			screen.getByTitle('Truth Sleuth Data Studio articles report'),
+		).toHaveAttribute('src', DATA_STUDIO_EMBED_SRC)
+		errorSpy.mockRestore()
+	})
+})

--- a/components/layout/Navbar.jsx
+++ b/components/layout/Navbar.jsx
@@ -32,6 +32,7 @@ import {
 	IoChevronBackOutline,
 	IoChevronForwardOutline,
 	IoLogOutOutline,
+	IoPulseOutline,
 } from 'react-icons/io5'
 import { HiOutlineDocumentPlus } from 'react-icons/hi2'
 import { Tooltip } from 'react-tooltip'
@@ -58,6 +59,7 @@ const DASHBOARD_VIEW_BY_TAB = [
 	'agencies',
 	'help',
 	'appearance',
+	'pipeline',
 ]
 
 /** Tooltip outside the drawer so overflow / motion transforms can't clip it. */
@@ -315,6 +317,16 @@ const Navbar = ({
 			{customClaims.admin && (
 				<NavItem
 					expanded
+					icon={icon(IoPulseOutline)}
+					label="Pipeline"
+					active={tab === 7}
+					onClick={() => handleTabNavigation(7)}
+					tooltipClass="tooltip-pipeline"
+				/>
+			)}
+			{customClaims.admin && (
+				<NavItem
+					expanded
 					icon={icon(IoBusinessOutline)}
 					label="Agencies"
 					active={tab === 4}
@@ -365,6 +377,16 @@ const Navbar = ({
 					active={tab === 0}
 					onClick={() => handleTabNavigation(0)}
 					tooltipClass="tooltip-home"
+				/>
+			)}
+			{customClaims.admin && (
+				<NavItem
+					expanded={false}
+					icon={icon(IoPulseOutline)}
+					label="Pipeline"
+					active={tab === 7}
+					onClick={() => handleTabNavigation(7)}
+					tooltipClass="tooltip-pipeline"
 				/>
 			)}
 			{customClaims.admin && (

--- a/functions/index.js
+++ b/functions/index.js
@@ -444,6 +444,10 @@ exports.previewBulkArchive = experimentFunctions.previewBulkArchive;
 exports.bulkArchiveReports = experimentFunctions.bulkArchiveReports;
 exports.getExperimentMetrics = experimentFunctions.getExperimentMetrics;
 
+const pipelineRunFunctions = require("./pipeline-runs");
+
+exports.getPipelineRuns = pipelineRunFunctions.getPipelineRuns;
+
 exports.authGetUserList = functions.https.onCall(async (data, context) => {
   // Ensure that the user is authenticated
   if (!context.auth) {

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "functions",
       "dependencies": {
+        "@google-cloud/bigquery": "^9.0.2",
         "@google-cloud/firestore": "^7.9.0",
         "@google-cloud/storage": "^7.0.1",
         "@sendgrid/mail": "^8.1.3",
@@ -177,6 +178,248 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@google-cloud/bigquery": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-9.0.2.tgz",
+      "integrity": "sha512-KLRSKdU+1VsXMDz9tmqtFASQXuBazLFN3VN8fTkuW/jDWWQK7HuNjT2RIKev+5xlBGfBsqQZs4Z5jqT0seV0aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/common": "^8.0.0",
+        "@google-cloud/paginator": "^7.0.0",
+        "@google-cloud/precise-date": "^6.0.0",
+        "@google-cloud/promisify": "^6.0.0",
+        "arrify": "^3.0.0",
+        "big.js": "^7.0.0",
+        "duplexify": "^4.1.3",
+        "extend": "^3.0.2",
+        "stream-events": "^1.0.5",
+        "teeny-request": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/bigquery/node_modules/@google-cloud/paginator": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-7.0.1.tgz",
+      "integrity": "sha512-k32cWlHAF8yTgg8rciLI8mPMI6UzuJdKp53YRxISRwMFxUl2FYplvs+Mr2UHxKn0W7rXsqZnUZy73AOJFDP8iA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/bigquery/node_modules/@google-cloud/promisify": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-6.0.1.tgz",
+      "integrity": "sha512-lpN2AtoQ/iimp7jjm5zJFWbpW7OJc5qWmQdt59CI4ENeoIRIx+yf2ShSR2kanQfjFOshA74eSbimXXuRaSCUVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/bigquery/node_modules/arrify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-3.0.0.tgz",
+      "integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@google-cloud/bigquery/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google-cloud/bigquery/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@google-cloud/bigquery/node_modules/teeny-request": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-11.0.1.tgz",
+      "integrity": "sha512-bNr5j2YjSdajgCVsp+8JVjRf1uHIbpNISLeKp/7V1NnVMX3Gh6H/kECNGlm2Q3I68ACODQ0iv6aZ3Rvm8WgLGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/common": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-8.0.1.tgz",
+      "integrity": "sha512-dAq3mwl7s6Zlw+YQazohVuC1BunrRRuPj8ufK4QbKLQGMZ+TPppWByvIEY67n3zCDWbv3XRh8rV9t6fPQ/qd7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/projectify": "^6.0.0",
+        "@google-cloud/promisify": "^6.0.0",
+        "arrify": "^2.0.0",
+        "duplexify": "^4.1.3",
+        "extend": "^3.0.2",
+        "google-auth-library": "^11.0.0",
+        "html-entities": "^2.5.2",
+        "retry-request": "^9.0.0",
+        "teeny-request": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/@google-cloud/projectify": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-6.0.1.tgz",
+      "integrity": "sha512-zA3o4l87UJ56odT/e9PcT4n2bqVnrp6dg9vI75DoGGbl0/YJemX8Fta7454htECt07eALxxc4iaAbrX3T+QulA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/@google-cloud/promisify": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-6.0.1.tgz",
+      "integrity": "sha512-lpN2AtoQ/iimp7jjm5zJFWbpW7OJc5qWmQdt59CI4ENeoIRIx+yf2ShSR2kanQfjFOshA74eSbimXXuRaSCUVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/gcp-metadata": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-9.0.3.tgz",
+      "integrity": "sha512-2YYnIlHaKBGT2IPg3G2M57hia9Galz15zsEOvw9T3oRf0lSn6KN6VcHQLqby7x8ksYKnjXvp3rp2KJyLCN6zfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.1.3",
+        "google-logging-utils": "^2.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/google-auth-library": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.2.tgz",
+      "integrity": "sha512-vzpgPutxrghPsnjrjpzLX2bdv8IOL719Rh0oEjGnQu8YCIbnbMuTTQ5zU9LcKvLdOPgCxBwppbvnhgW90Qna5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "^9.0.0",
+        "google-logging-utils": "^2.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/retry-request": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-9.0.1.tgz",
+      "integrity": "sha512-4kGHEBl0ME6gR+8QB1sPMyg58jUxLUcCZNeqLDrfqzk0eWQN8XJFmeu7fmZCjlZCRW0S2u64Ik1HkO/0sWgCYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/teeny-request": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-11.0.1.tgz",
+      "integrity": "sha512-bNr5j2YjSdajgCVsp+8JVjRf1uHIbpNISLeKp/7V1NnVMX3Gh6H/kECNGlm2Q3I68ACODQ0iv6aZ3Rvm8WgLGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@google-cloud/firestore": {
       "version": "7.11.6",
       "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.6.tgz",
@@ -204,6 +447,15 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/precise-date": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-6.0.0.tgz",
+      "integrity": "sha512-m/TqW1Nh1j/O5tyzm3A0mE+3mIc3kvjMSCZedeUy8urDFkoMbp3lyHrzGek/rc9XvcnS4M8ly1pDWaTH32TFSw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@google-cloud/projectify": {
@@ -862,6 +1114,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/big.js": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-7.0.1.tgz",
+      "integrity": "sha512-iFgV784tD8kq4ccF1xtNMZnXeZzVuXWWM+ERFzKQjv+A5G9HC8CY3DuV45vgzFFcW+u2tIvmF95+AzWgs6BjCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
@@ -1183,6 +1448,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -1745,6 +2019,29 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -1925,6 +2222,18 @@
       },
       "engines": {
         "node": ">= 0.12"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -2157,6 +2466,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-2.0.1.tgz",
+      "integrity": "sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/gopd": {
@@ -2842,6 +3160,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -3840,6 +4178,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -14,6 +14,7 @@
   },
   "main": "index.js",
   "dependencies": {
+    "@google-cloud/bigquery": "^9.0.2",
     "@google-cloud/firestore": "^7.9.0",
     "@google-cloud/storage": "^7.0.1",
     "@sendgrid/mail": "^8.1.3",

--- a/functions/pipeline-runs.js
+++ b/functions/pipeline-runs.js
@@ -1,0 +1,126 @@
+/**
+ * Admin-only pipeline rundown from BigQuery `truth_sleuth.pipeline_runs`.
+ *
+ * IAM (one-time, project misinfo-5d004): grant the Functions runtime
+ * service account (`misinfo-5d004@appspot.gserviceaccount.com` for v1
+ * callables) BigQuery Job User plus Data Viewer on dataset `truth_sleuth`.
+ */
+
+const functions = require("firebase-functions/v1");
+const {BigQuery} = require("@google-cloud/bigquery");
+
+const PROJECT_ID = "misinfo-5d004";
+const DATASET_ID = "truth_sleuth";
+const TABLE_ID = "pipeline_runs";
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+
+/**
+ * @param {import("firebase-functions/v1").https.CallableContext} context
+ */
+function requireAdmin(context) {
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+        "unauthenticated",
+        "Must be signed in.",
+    );
+  }
+  if (!context.auth.token.admin) {
+    throw new functions.https.HttpsError(
+        "permission-denied",
+        "Admin privileges required.",
+    );
+  }
+}
+
+/**
+ * Clamp the requested row count to a safe range.
+ *
+ * @param {unknown} raw
+ * @returns {number}
+ */
+function parseLimit(raw) {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return DEFAULT_LIMIT;
+  return Math.min(MAX_LIMIT, Math.max(1, Math.trunc(n)));
+}
+
+/**
+ * Turn a BigQuery cell into a JSON-safe value.
+ *
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+function serializeValue(value) {
+  if (value == null) return null;
+  const valueType = typeof value;
+  if (valueType === "string" ||
+      valueType === "number" ||
+      valueType === "boolean") {
+    return value;
+  }
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value.toNumber === "function") {
+    try {
+      return value.toNumber();
+    } catch (_err) {
+      return String(value);
+    }
+  }
+  if (typeof value.value === "string" || typeof value.value === "number") {
+    return value.value;
+  }
+  return String(value);
+}
+
+/**
+ * Flatten one BigQuery row for the dashboard.
+ *
+ * @param {Record<string, unknown>} row
+ * @returns {Record<string, unknown>}
+ */
+function serializeRow(row) {
+  const out = {};
+  for (const [key, value] of Object.entries(row || {})) {
+    out[key] = serializeValue(value);
+  }
+  return out;
+}
+
+/**
+ * Admin callable: recent Truth Sleuth pipeline run summaries.
+ *
+ * @example
+ * await getPipelineRuns({ limit: 20 });
+ */
+exports.getPipelineRuns = functions.https.onCall(async (data, context) => {
+  requireAdmin(context);
+
+  const limit = parseLimit(data && data.limit);
+  const table = `\`${PROJECT_ID}.${DATASET_ID}.${TABLE_ID}\``;
+  const query = `
+    SELECT *
+    FROM ${table}
+    ORDER BY COALESCE(load_timestamp, SAFE.TIMESTAMP(recorded_at)) DESC
+    LIMIT @limit
+  `;
+
+  try {
+    const bigquery = new BigQuery({projectId: PROJECT_ID});
+    const [rows] = await bigquery.query({
+      query,
+      params: {limit},
+      types: {limit: "INT64"},
+      location: "US",
+    });
+    return {
+      runs: (rows || []).map(serializeRow),
+    };
+  } catch (error) {
+    console.error("Failed to query pipeline_runs:", error);
+    throw new functions.https.HttpsError(
+        "internal",
+        "Failed to load pipeline runs.",
+    );
+  }
+});

--- a/pages/dashboard.jsx
+++ b/pages/dashboard.jsx
@@ -38,6 +38,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Head from 'next/head'
 import HelpRequests from '../components/admin/HelpRequests'
 import Appearance from '../components/admin/Appearance'
+import Pipeline from '../components/admin/Pipeline'
 
 /** Stable view names synced to `?view=` so refresh restores the active tab. */
 const VIEW_BY_TAB = [
@@ -48,6 +49,7 @@ const VIEW_BY_TAB = [
 	'agencies',
 	'help',
 	'appearance',
+	'pipeline',
 ]
 
 /**
@@ -62,8 +64,14 @@ function isTabAllowed(tabIndex, claims) {
 	if (tabIndex === 0 || tabIndex === 2) {
 		return !!(claims.admin || claims.agency)
 	}
-	// Users (3) and admin-only tools
-	if (tabIndex === 3 || tabIndex === 4 || tabIndex === 5 || tabIndex === 6) {
+	// Users (3) and admin-only tools (agencies, help, appearance, pipeline)
+	if (
+		tabIndex === 3 ||
+		tabIndex === 4 ||
+		tabIndex === 5 ||
+		tabIndex === 6 ||
+		tabIndex === 7
+	) {
 		return !!claims.admin
 	}
 	return false
@@ -230,6 +238,7 @@ function DashboardLayout({
 				)}
 				{tab == 5 && customClaims.admin && <HelpRequests />}
 				{tab == 6 && customClaims.admin && <Appearance />}
+				{tab == 7 && customClaims.admin && <Pipeline />}
 			</div>
 			{newReportModal && (
 				<AgencyReportModal

--- a/utils/__tests__/pipeline-runs.test.js
+++ b/utils/__tests__/pipeline-runs.test.js
@@ -1,0 +1,99 @@
+import {
+	DATA_STUDIO_EMBED_SRC,
+	formatCount,
+	formatDuration,
+	formatHealth,
+	formatIssueMessage,
+	formatRunTimestamp,
+	healthBadgeClass,
+	parseJsonArray,
+	pipelineRunKey,
+} from '../pipeline-runs'
+
+describe('formatCount', () => {
+	it('formats numbers and uses an em dash for empty values', () => {
+		expect(formatCount(1200)).toBe('1,200')
+		expect(formatCount(0)).toBe('0')
+		expect(formatCount(null)).toBe('—')
+		expect(formatCount('')).toBe('—')
+	})
+})
+
+describe('formatDuration', () => {
+	it('formats seconds into a short duration', () => {
+		expect(formatDuration(45)).toBe('45s')
+		expect(formatDuration(125)).toBe('2m 5s')
+		expect(formatDuration(3720)).toBe('1h 2m')
+		expect(formatDuration(null)).toBe('—')
+	})
+})
+
+describe('formatRunTimestamp', () => {
+	it('turns a night key into a readable timestamp', () => {
+		expect(formatRunTimestamp('20260811_070316')).toBe('2026-08-11 07:03')
+		expect(formatRunTimestamp('not-a-stamp')).toBe('not-a-stamp')
+		expect(formatRunTimestamp('')).toBe('—')
+	})
+})
+
+describe('formatHealth', () => {
+	it('falls back to unknown', () => {
+		expect(formatHealth('ok')).toBe('ok')
+		expect(formatHealth('')).toBe('unknown')
+	})
+})
+
+describe('healthBadgeClass', () => {
+	it('maps health to badge colors', () => {
+		expect(healthBadgeClass('ok')).toContain('green')
+		expect(healthBadgeClass('warning')).toContain('amber')
+		expect(healthBadgeClass('critical')).toContain('red')
+		expect(healthBadgeClass('')).toContain('gray')
+	})
+})
+
+describe('parseJsonArray', () => {
+	it('parses JSON arrays and ignores junk', () => {
+		expect(parseJsonArray('["a","b"]')).toEqual(['a', 'b'])
+		expect(parseJsonArray([{ code: 'x' }])).toEqual([{ code: 'x' }])
+		expect(parseJsonArray('')).toEqual([])
+		expect(parseJsonArray('{not json')).toEqual([])
+		expect(parseJsonArray('{"a":1}')).toEqual([])
+	})
+})
+
+describe('formatIssueMessage', () => {
+	it('prefers message then code', () => {
+		expect(formatIssueMessage({ message: 'Too few curated' })).toBe(
+			'Too few curated',
+		)
+		expect(formatIssueMessage({ code: 'curated_below_minimum' })).toBe(
+			'curated_below_minimum',
+		)
+		expect(formatIssueMessage('plain')).toBe('plain')
+		expect(formatIssueMessage({})).toBe('')
+	})
+})
+
+describe('pipelineRunKey', () => {
+	it('joins identifying fields', () => {
+		expect(
+			pipelineRunKey(
+				{
+					run_timestamp: '20260811_070316',
+					measurement_run_id: 'production_daily',
+					execution_name: 'truth-sleuth-test-abc',
+				},
+				0,
+			),
+		).toBe('20260811_070316|production_daily|truth-sleuth-test-abc|0')
+	})
+})
+
+describe('DATA_STUDIO_EMBED_SRC', () => {
+	it('points at the Truth Sleuth articles report', () => {
+		expect(DATA_STUDIO_EMBED_SRC).toContain(
+			'c39e73c0-db85-44c2-9ea0-a12de00953b3',
+		)
+	})
+})

--- a/utils/fetch-pipeline-runs.js
+++ b/utils/fetch-pipeline-runs.js
@@ -1,0 +1,18 @@
+/**
+ * Loads recent pipeline rundown rows for signed-in admins.
+ */
+
+import { getFunctions, httpsCallable } from 'firebase/functions'
+import { app } from '../config/firebase'
+
+/**
+ * @param {number} [limit]
+ * @returns {Promise<Record<string, unknown>[]>}
+ */
+export async function fetchPipelineRuns(limit = 20) {
+	const fn = getFunctions(app, 'us-central1')
+	const getPipelineRuns = httpsCallable(fn, 'getPipelineRuns')
+	const result = await getPipelineRuns({ limit })
+	const runs = result?.data?.runs
+	return Array.isArray(runs) ? runs : []
+}

--- a/utils/pipeline-runs.js
+++ b/utils/pipeline-runs.js
@@ -1,0 +1,139 @@
+/**
+ * Display helpers for Truth Sleuth pipeline run summaries.
+ * Turns BigQuery rundown rows into labels, counts, and issue lists for the
+ * admin Pipeline tab.
+ */
+
+export const DATA_STUDIO_EMBED_SRC =
+	'https://datastudio.google.com/embed/reporting/c39e73c0-db85-44c2-9ea0-a12de00953b3/page/tEnnC'
+
+export const DATA_STUDIO_EMBED_SANDBOX =
+	'allow-storage-access-by-user-activation allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox'
+
+export const FUNNEL_STAGES = [
+	{ key: 'links_rows', label: 'Links' },
+	{ key: 'extracted_rows', label: 'Extracted' },
+	{ key: 'election_rows', label: 'Election' },
+	{ key: 'geographic_rows', label: 'Geographic' },
+	{ key: 'clustered_rows', label: 'Clustered' },
+	{ key: 'curated_rows', label: 'Curated' },
+	{ key: 'dashboard_rows', label: 'Dashboard' },
+]
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function formatCount(value) {
+	if (value == null || value === '') return '—'
+	const n = Number(value)
+	if (!Number.isFinite(n)) return '—'
+	return n.toLocaleString()
+}
+
+/**
+ * @param {unknown} seconds
+ * @returns {string}
+ */
+export function formatDuration(seconds) {
+	if (seconds == null || seconds === '') return '—'
+	const total = Number(seconds)
+	if (!Number.isFinite(total) || total < 0) return '—'
+	const rounded = Math.round(total)
+	const hours = Math.floor(rounded / 3600)
+	const minutes = Math.floor((rounded % 3600) / 60)
+	const secs = rounded % 60
+	if (hours > 0) return `${hours}h ${minutes}m`
+	if (minutes > 0) return `${minutes}m ${secs}s`
+	return `${secs}s`
+}
+
+/**
+ * @param {unknown} value Night key like `20260811_070316`
+ * @returns {string}
+ */
+export function formatRunTimestamp(value) {
+	if (typeof value !== 'string' || !value.trim()) return '—'
+	const match = value
+		.trim()
+		.match(/^(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})$/)
+	if (!match) return value.trim()
+	return `${match[1]}-${match[2]}-${match[3]} ${match[4]}:${match[5]}`
+}
+
+/**
+ * @param {unknown} status
+ * @returns {string}
+ */
+export function formatHealth(status) {
+	const key = String(status || '').trim()
+	return key || 'unknown'
+}
+
+/**
+ * Tailwind classes for a health pill.
+ *
+ * @param {unknown} status
+ * @returns {string}
+ */
+export function healthBadgeClass(status) {
+	const key = String(status || '')
+		.trim()
+		.toLowerCase()
+	if (key === 'ok') return 'bg-green-100 text-green-800'
+	if (key === 'warning') return 'bg-amber-100 text-amber-800'
+	if (key === 'critical') return 'bg-red-100 text-red-800'
+	return 'bg-gray-100 text-gray-700'
+}
+
+/**
+ * Parse `issues_json` / `steps_completed_json` cells.
+ *
+ * @param {unknown} raw
+ * @returns {unknown[]}
+ */
+export function parseJsonArray(raw) {
+	if (Array.isArray(raw)) return raw
+	if (typeof raw !== 'string' || !raw.trim()) return []
+	try {
+		const parsed = JSON.parse(raw)
+		return Array.isArray(parsed) ? parsed : []
+	} catch {
+		return []
+	}
+}
+
+/**
+ * @param {unknown} issue
+ * @returns {string}
+ */
+export function formatIssueMessage(issue) {
+	if (typeof issue === 'string') return issue
+	if (issue && typeof issue === 'object') {
+		const row = /** @type {{ message?: unknown, code?: unknown }} */ (issue)
+		if (typeof row.message === 'string' && row.message.trim()) {
+			return row.message.trim()
+		}
+		if (typeof row.code === 'string' && row.code.trim()) {
+			return row.code.trim()
+		}
+	}
+	return ''
+}
+
+/**
+ * Stable key for a rundown row.
+ *
+ * @param {Record<string, unknown>} run
+ * @param {number} [index]
+ * @returns {string}
+ */
+export function pipelineRunKey(run, index = 0) {
+	const parts = [
+		run?.run_timestamp,
+		run?.measurement_run_id,
+		run?.execution_name,
+		index,
+	].filter((part) => part != null && part !== '')
+	return parts.join('|') || String(index)
+}


### PR DESCRIPTION
Admin-only Pipeline tab so you can check last night’s job without asking the agent. Scoreboard + table from BigQuery, details beside the row you click, Data Studio underneath.

## Summary
- Add an admin-only **Pipeline** tab (`/dashboard?view=pipeline`) with recent Truth Sleuth run health from `truth_sleuth.pipeline_runs`.
- New `getPipelineRuns` callable (admin-only) queries BigQuery; newsrooms never see the tab.
- Embed the existing Data Studio articles report under the rundown (still needs a Google account that can open that report).
- Table ~75% / details ~25% on one row; table max height 550px with sticky headers and scrolling rows.

## Test plan
- [ ] Log in as admin → Pipeline is in the sidebar after Home; rundown loads; click a row updates details.
- [ ] Agency / public users do not see Pipeline; `?view=pipeline` does not show the page.
- [ ] Data Studio iframe loads for a Google account that already has report access.
- [ ] `npm test` and `npm run build` pass.